### PR TITLE
add vscode-java-test/0.28.1; switch to...

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -2,50 +2,35 @@ version: 1.0.0
 plugins:
   - repository:
       url: 'https://github.com/microsoft/vscode-pull-request-github'
-      revision: 0.20.0
+      revision: 0.21.1
     aliases:
       - ms-vscode/vscode-github-pullrequest
-    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v4c5e8c4/vscode-pull-request-github-0.21.1.vsix
+    extension: https://github.com/microsoft/vscode-pull-request-github/releases/download/0.21.1/vscode-pull-request-github-0.21.1.vsix
   - repository:
-      url: 'https://github.com/Microsoft/vscode-node-debug'
-      revision: v1.41.1
+      url: 'https://github.com/microsoft/vscode-js-debug'
+      revision: v1.66.0
     sidecar:
-      image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
-      name: vscode-node-debug
+      directory: node
+      name: jsdebug
       memoryLimit: 512Mi
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-node-debug/node-debug-1.41.1.vsix
-  - repository:
-      url: 'https://github.com/Microsoft/vscode-node-debug2'
-      revision: v1.42.3
-    metaYaml:
-      extraDependencies:
-        - ms-vscode/node-debug
-    preferences:
-      debug.node.useV3: false
-    sidecar:
-      image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
-      name: vscode-node
-      memoryLimit: 1Gi
-      memoryRequest: 20Mi
-      cpuLimit: 500m
-      cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-node-debug2/node-debug2-1.42.3.vsix
+    extension: https://open-vsx.org/api/ms-vscode/js-debug/1.66.0/file/ms-vscode.js-debug-1.66.0.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode'
       revision: 1.49.3
       directory: extensions/typescript-language-features
     featured: true
+    aliases:
+      - che-incubator/typescript
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       memoryLimit: 512Mi
-      name: vscode-node
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v2cebc1e/typescript-language-features-1.49.3.vsix
+    extension: https://open-vsx.org/api/vscode/typescript-language-features/1.49.3/file/vscode.typescript-language-features-1.49.3.vsix
   - repository:
       url: https://github.com/clangd/vscode-clangd
       revision: c7f4a1b84fcc10d5b8241750cf2a84097ee4c37e
@@ -92,7 +77,7 @@ plugins:
     extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-vscode/cdt-vscode-0.0.7-75cf95.vsix
   - repository:
       url: 'https://github.com/bmewburn/vscode-intelephense'
-      revision: v1.3.11
+      revision: v1.5.4
     featured: true
     aliases:
       - redhat/php
@@ -103,7 +88,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-intelephense/vscode-intelephense-client-1.3.11.vsix
+    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-intelephense/vscode-intelephense-client-1.5.4.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode-python'
       revision: 2020.7.94776
@@ -117,7 +102,7 @@ plugins:
       cpuRequest: 30m
       volumeMounts:
         - name: venv
-          path: /home/jboss/.venv
+          path: /home/user/.venv
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v34b6b7e/vscode-python-2020.7.94776.vsix
   - repository:
       url: 'https://github.com/golang/vscode-go'
@@ -157,9 +142,9 @@ plugins:
       cpuRequest: 30m
       volumeMounts:
         - name: m2
-          path: /home/jboss/.m2
+          path: /home/user/.m2
         - name: gradle
-          path: /home/jboss/.gradle
+          path: /home/user/.gradle
     extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-microprofile/vscode-microprofile-0.1.1-48.vsix
   - id: redhat/quarkus-java11
     repository:
@@ -176,9 +161,9 @@ plugins:
       cpuRequest: 30m
       volumeMounts:
         - name: m2
-          path: /home/jboss/.m2
+          path: /home/user/.m2
         - name: gradle
-          path: /home/jboss/.gradle
+          path: /home/user/.gradle
     extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-quarkus/vscode-quarkus-1.7.0-437.vsix
     metaYaml:
       skipDependencies:
@@ -293,9 +278,9 @@ plugins:
           value: /opt/gradle/
       volumeMounts:
         - name: m2
-          path: /home/jboss/.m2
+          path: /home/user/.m2
         - name: gradle
-          path: /home/jboss/.gradle
+          path: /home/user/.gradle
     extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix
     metaYaml:
       extraDependencies:
@@ -315,7 +300,7 @@ plugins:
       cpuRequest: 30m
       volumeMounts:
         - name: m2
-          path: /home/jboss/.m2
+          path: /home/user/.m2
     extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.63.0-2222.vsix
     metaYaml:
       extraDependencies:
@@ -349,7 +334,7 @@ plugins:
         - redhat/vscode-commons
   - repository:
       url: 'https://github.com/redhat-developer/vscode-xml'
-      revision: 0.14.0
+      revision: 0.17.0
     featured: true
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
@@ -358,7 +343,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v356aec7/vscode-xml-0.14.0.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v069c634/vscode-xml-0.17.0.vsix
   - repository:
       url: 'https://github.com/Azure/vscode-kubernetes-tools'
       revision: 1.2.1
@@ -395,7 +380,7 @@ plugins:
       cpuRequest: 30m
       volumeMounts:
         - name: nuget
-          path: /home/jboss/.nuget
+          path: /home/user/.nuget
     extension: https://github.com/redhat-developer/omnisharp-theia-plugin/releases/download/v0.0.6/omnisharp_theia_plugin.theia
   - repository:
       url: 'https://github.com/SonarSource/sonarlint-vscode'
@@ -409,7 +394,7 @@ plugins:
       cpuRequest: 30m
       volumeMounts:
         - name: m2
-          path: /home/jboss/.m2
+          path: /home/user/.m2
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v8521e74/vscode-sonarlint-1.20.1.vsix
   - repository:
       url: 'https://github.com/microsoft/vscode-eslint'

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -275,7 +275,7 @@ plugins:
           path: /home/user/.m2
         - name: gradle
           path: /home/user/.gradle
-    extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix
+    extension: https://open-vsx.org/api/redhat/java/0.82.0/file/redhat.java-0.82.0.vsix
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
@@ -295,7 +295,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
-    extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.63.0-2222.vsix
+    extension: https://open-vsx.org/api/redhat/java/0.63.0/file/redhat.java-0.63.0.vsix
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -68,7 +68,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-vscode/cdt-vscode-0.0.7-75cf95.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/0.0.7-75cf95-cdt-vscode-assets/cdt-vscode-0.0.7-75cf95.vsix
   - repository:
       url: 'https://github.com/bmewburn/vscode-intelephense'
       revision: v1.8.2

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -140,7 +140,7 @@ plugins:
   - id: redhat/vscode-quarkus
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'
-      revision: v1.7.0
+      revision: v1.9.0
     aliases:
       - redhat/quarkus-java11
     preferences:
@@ -157,7 +157,7 @@ plugins:
           path: /home/user/.m2
         - name: gradle
           path: /home/user/.gradle
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-quarkus/vscode-quarkus-1.7.0-437.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-quarkus/1.9.0/file/redhat.vscode-quarkus-1.9.0.vsix
     metaYaml:
       skipDependencies:
         - redhat/vscode-commons
@@ -166,19 +166,19 @@ plugins:
         - vscjava/vscode-java-test
   - repository:
       url: 'https://github.com/camel-tooling/vscode-wsdl2rest'
-      revision: 0.0.11
+      revision: 0.0.15
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       memoryLimit: 256Mi
       memoryRequest: 20Mi
       cpuLimit: 800m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.11-106.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-wsdl2rest/0.0.15/file/redhat.vscode-wsdl2rest-0.0.15.vsix
     deprecate:
       automigrate: false
   - repository:
       url: 'https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension'
-      revision: 0.2.1
+      revision: 0.3.5
     aliases:
       - redhat/dependency-analytics
     sidecar:
@@ -188,13 +188,13 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.2.1/fabric8-analytics-0.2.1.vsix
+    extension: https://open-vsx.org/api/redhat/fabric8-analytics/0.3.5/file/redhat.fabric8-analytics-0.3.5.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-project-initializer'
-      revision: v0.0.10
+      revision: v0.2.1
     aliases:
       - redhat/project-initializer
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-project-initializer/project-initializer-0.0.10-582.vsix
+    extension: https://open-vsx.org/api/redhat/project-initializer/0.2.1/file/redhat.project-initializer-0.2.1.vsix
   - repository:
       url: 'https://github.com/che-incubator/che-theia-openshift-auth'
       revision: 0.0.3

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -10,7 +10,7 @@ plugins:
       url: 'https://github.com/microsoft/vscode-js-debug'
       revision: v1.66.0
     sidecar:
-      directory: node
+      image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       name: jsdebug
       memoryLimit: 512Mi
       memoryRequest: 20Mi
@@ -60,12 +60,6 @@ plugins:
   - repository:
       url: 'https://github.com/eclipse-cdt/cdt-vscode'
       revision: 2edfc3a3474bc7a732014e1a4631561b991f845a
-    aliases:
-      - che-incubator/cpptools
-    metaYaml:
-      extraDependencies:
-        - eclipse-cdt/cdt-gdb-vscode
-        - llvm-vs-code-extensions/vscode-clangd
     featured: true
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
@@ -79,11 +73,8 @@ plugins:
       url: 'https://github.com/bmewburn/vscode-intelephense'
       revision: v1.5.4
     featured: true
-    aliases:
-      - redhat/php
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
-      name: php-intelephense
       memoryLimit: 1Gi
       memoryRequest: 20Mi
       cpuLimit: 500m
@@ -106,7 +97,7 @@ plugins:
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v34b6b7e/vscode-python-2020.7.94776.vsix
   - repository:
       url: 'https://github.com/golang/vscode-go'
-      revision: v0.16.1
+      revision: v0.23.0
     featured: true
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
@@ -117,8 +108,8 @@ plugins:
       cpuRequest: 30m
       env:
         - name: GOPATH
-          value: /projects/.che/gopath:$(CHE_PROJECTS_ROOT)
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-go/go-0.16.1.vsix
+          value: '/projects/.che/gopath:/go:$(CHE_PROJECTS_ROOT)'
+    extension: https://github.com/golang/vscode-go/releases/download/v0.23.0/go-0.23.0.vsix
   - repository:
       url: 'https://github.com/camel-tooling/vscode-camelk'
       revision: 0.0.26
@@ -146,10 +137,12 @@ plugins:
         - name: gradle
           path: /home/user/.gradle
     extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-microprofile/vscode-microprofile-0.1.1-48.vsix
-  - id: redhat/quarkus-java11
+  - id: redhat/vscode-quarkus
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'
       revision: v1.7.0
+    aliases:
+      - redhat/quarkus-java11
     preferences:
       java.server.launchMode: Standard
     sidecar:
@@ -170,20 +163,22 @@ plugins:
         - redhat/vscode-commons
       extraDependencies:
         - vscjava/vscode-java-debug
+        - vscjava/vscode-java-test
   - repository:
       url: 'https://github.com/camel-tooling/vscode-wsdl2rest'
       revision: 0.0.11
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       memoryLimit: 256Mi
-      name: vscode-wsdl2rest
       memoryRequest: 20Mi
-      cpuLimit: 500m
+      cpuLimit: 800m
       cpuRequest: 30m
     extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.11-106.vsix
+    deprecate:
+      automigrate: false
   - repository:
       url: 'https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension'
-      revision: 0.1.0
+      revision: 0.2.1
     aliases:
       - redhat/dependency-analytics
     sidecar:
@@ -193,7 +188,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.1.0/fabric8-analytics-0.1.0.vsix
+    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.2.1/fabric8-analytics-0.2.1.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-project-initializer'
       revision: v0.0.10
@@ -215,7 +210,7 @@ plugins:
     extension: https://github.com/che-incubator/che-theia-openshift-auth/releases/download/0.0.3/che-openshift-authentication-plugin-0.0.3.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-openshift-tools'
-      revision: v0.2.11
+      revision: v0.2.13
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       name: vscode-openshift-connector
@@ -226,12 +221,11 @@ plugins:
       volumeMounts:
         - name: kube
           path: /home/theia/.kube
-    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/va21efef/vscode-openshift-connector-v0.2.11.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-openshift-connector/0.2.13/file/redhat.vscode-openshift-connector-0.2.13.vsix
     metaYaml:
       extraDependencies:
         - ms-kubernetes-tools/vscode-kubernetes-tools
         - redhat/vscode-yaml
-        - che-theia/che-openshift-authentication-plugin
   - repository:
       url: 'https://github.com/redhat-developer/vscode-yaml'
       revision: 0.14.0
@@ -309,6 +303,7 @@ plugins:
       url: 'https://github.com/felixfbecker/vscode-php-debug'
       revision: v1.13.0
     aliases:
+      - felixfbecker/vscode-php-debug
       - redhat/php-debugger
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -123,7 +123,7 @@ plugins:
     extension: https://open-vsx.org/api/redhat/vscode-camelk/0.0.30/file/redhat.vscode-camelk-0.0.30.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-microprofile'
-      revision: 174c77f51a57bf1cfadba8f78ad7072ce63baa1d
+      revision: 0.3.0
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       name: vscode-microp
@@ -136,7 +136,7 @@ plugins:
           path: /home/user/.m2
         - name: gradle
           path: /home/user/.gradle
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-microprofile/vscode-microprofile-0.1.1-48.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-microprofile/0.3.0/file/redhat.vscode-microprofile-0.3.0.vsix
   - id: redhat/vscode-quarkus
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -33,7 +33,7 @@ plugins:
     extension: https://open-vsx.org/api/vscode/typescript-language-features/1.49.3/file/vscode.typescript-language-features-1.49.3.vsix
   - repository:
       url: https://github.com/clangd/vscode-clangd
-      revision: c7f4a1b84fcc10d5b8241750cf2a84097ee4c37e
+      revision: 0.1.15
     metaYaml:
      skipIndex: true
     sidecar:
@@ -43,10 +43,10 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-clangd/vscode-clangd-0.1.5-562d00.vsix
+    extension: https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.15/file/llvm-vs-code-extensions.vscode-clangd-0.1.15.vsix
   - repository:
       url: https://github.com/eclipse-cdt/cdt-gdb-vscode
-      revision: 2cbbb857a2acf0b2e46bab30e0cbbfb547514856
+      revision: 528a63de7e21d3e62d9e8aad6491718b69ec311e
     metaYaml:
      skipIndex: true
     sidecar:
@@ -56,7 +56,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-gdb-vscode/cdt-gdb-vscode-0.0.91-2cbbb8.vsix
+    extension: https://open-vsx.org/api/eclipse-cdt/cdt-gdb-vscode/0.0.92/file/eclipse-cdt.cdt-gdb-vscode-0.0.92.vsix
   - repository:
       url: 'https://github.com/eclipse-cdt/cdt-vscode'
       revision: 2edfc3a3474bc7a732014e1a4631561b991f845a
@@ -71,7 +71,7 @@ plugins:
     extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-vscode/cdt-vscode-0.0.7-75cf95.vsix
   - repository:
       url: 'https://github.com/bmewburn/vscode-intelephense'
-      revision: v1.5.4
+      revision: v1.8.2
     featured: true
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
@@ -79,7 +79,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-intelephense/vscode-intelephense-client-1.5.4.vsix
+    extension: https://open-vsx.org/api/bmewburn/vscode-intelephense-client/1.8.2/file/bmewburn.vscode-intelephense-client-1.8.2.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode-python'
       revision: 2020.7.94776

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -212,7 +212,20 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/ve96a2bb/vscode-yaml-0.14.0.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-yaml/0.14.0/file/redhat.vscode-yaml-0.14.0.vsix
+  - repository:
+      url: 'https://github.com/microsoft/vscode-java-test'
+      revision: 0.28.1
+    metaYaml:
+      skipIndex: true
+    sidecar:
+      directory: java
+      name: vscode-java
+      memoryLimit: 1500Mi
+      memoryRequest: 20Mi
+      cpuLimit: 500m
+      cpuRequest: 30m
+    extension: https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix
   - repository:
       url: 'https://github.com/microsoft/vscode-java-debug'
       revision: 0.26.0
@@ -254,6 +267,7 @@ plugins:
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
+        - vscjava/vscode-java-test
   - id: redhat/java8
     repository:
       url: 'https://github.com/redhat-developer/vscode-java'
@@ -274,6 +288,7 @@ plugins:
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
+        - vscjava/vscode-java-test
   - repository:
       url: 'https://github.com/felixfbecker/vscode-php-debug'
       revision: v1.22.0

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -112,7 +112,7 @@ plugins:
     extension: https://github.com/golang/vscode-go/releases/download/v0.23.0/go-0.23.0.vsix
   - repository:
       url: 'https://github.com/camel-tooling/vscode-camelk'
-      revision: 0.0.26
+      revision: 0.0.30
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       name: vscode-camelk
@@ -120,7 +120,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.26-336.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-camelk/0.0.30/file/redhat.vscode-camelk-0.0.30.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-microprofile'
       revision: 174c77f51a57bf1cfadba8f78ad7072ce63baa1d
@@ -301,7 +301,7 @@ plugins:
         - vscjava/vscode-java-debug
   - repository:
       url: 'https://github.com/felixfbecker/vscode-php-debug'
-      revision: v1.13.0
+      revision: v1.22.0
     aliases:
       - felixfbecker/vscode-php-debug
       - redhat/php-debugger
@@ -312,10 +312,10 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-php-debug/php-debug-1.13.0.vsix
+    extension: https://open-vsx.org/api/felixfbecker/php-debug/1.22.0/file/felixfbecker.php-debug-1.22.0.vsix
   - repository:
       url: 'https://github.com/camel-tooling/camel-lsp-client-vscode'
-      revision: 0.1.5
+      revision: 0.2.0
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
       name: vscode-apache-camel
@@ -323,7 +323,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.1.5-1377.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-apache-camel/0.2.0/file/redhat.vscode-apache-camel-0.2.0.vsix
     metaYaml:
       skipDependencies:
         - redhat/vscode-commons

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -165,18 +165,6 @@ plugins:
         - vscjava/vscode-java-debug
         - vscjava/vscode-java-test
   - repository:
-      url: 'https://github.com/camel-tooling/vscode-wsdl2rest'
-      revision: 0.0.15
-    sidecar:
-      image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
-      memoryLimit: 256Mi
-      memoryRequest: 20Mi
-      cpuLimit: 800m
-      cpuRequest: 30m
-    extension: https://open-vsx.org/api/redhat/vscode-wsdl2rest/0.0.15/file/redhat.vscode-wsdl2rest-0.0.15.vsix
-    deprecate:
-      automigrate: false
-  - repository:
       url: 'https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension'
       revision: 0.3.5
     aliases:
@@ -195,19 +183,6 @@ plugins:
     aliases:
       - redhat/project-initializer
     extension: https://open-vsx.org/api/redhat/project-initializer/0.2.1/file/redhat.project-initializer-0.2.1.vsix
-  - repository:
-      url: 'https://github.com/che-incubator/che-theia-openshift-auth'
-      revision: 0.0.3
-    sidecar:
-      image: "registry.redhat.io/codeready-workspaces/udi-rhel8:2.16"
-      name: vscode-openshift-connector
-      memoryLimit: 1500Mi
-      memoryRequest: 20Mi
-      cpuLimit: 800m
-      cpuRequest: 30m
-    metaYaml:
-      skipIndex: true
-    extension: https://github.com/che-incubator/che-theia-openshift-auth/releases/download/0.0.3/che-openshift-authentication-plugin-0.0.3.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-openshift-tools'
       revision: v0.2.13
@@ -250,7 +225,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 800m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
+    extension: https://open-vsx.org/api/vscjava/vscode-java-debug/0.26.0/file/vscjava.vscode-java-debug-0.26.0.vsix
   - id: redhat/java
     repository:
       url: 'https://github.com/redhat-developer/vscode-java'
@@ -349,7 +324,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.2.1.vsix
+    extension: https://open-vsx.org/api/ms-kubernetes-tools/vscode-kubernetes-tools/1.2.1/file/ms-kubernetes-tools.vscode-kubernetes-tools-1.2.1.vsix
   - id: redhat-developer/netcoredbg-theia-plugin
     repository:
       url: 'https://github.com/redhat-developer/netcoredbg-theia-plugin'
@@ -393,5 +368,5 @@ plugins:
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v8521e74/vscode-sonarlint-1.20.1.vsix
   - repository:
       url: 'https://github.com/microsoft/vscode-eslint'
-      revision: 1e15d3495da89072d48cf583d48d92829f0c4b82
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-eslint-2.1.1-1e15d3.vsix
+      revision: release/2.1.20
+    extension: https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.20/file/dbaeumer.vscode-eslint-2.1.20.vsix


### PR DESCRIPTION
### What does this PR do?

* 6b80d1a8 - (HEAD -> CRW-2662-update-crw-theia-plugins_2, origin/CRW-2662-update-crw-theia-plugins_2) add vscode-java-test/0.28.1; switch to openvsx hosted file for vscode-yaml/0.14.0 nboldt@redhat.com (55 seconds ago)
* b4daf485 - switch to GH release hosted file for cdt-vscode-0.0.7-75cf95.vsix nboldt@redhat.com (55 seconds ago)
* 894fb9c0 - remove wsdl2rest and che-theia-openshift-auth; switch to openvsx version of java-debug-0.26.0, kubernetes-tools-1.2.1, and bump to dbaeumer.vscode-eslint-2.1.20 nboldt@redhat.com (55 seconds ago)
* 2829eb2b - bump to newer plugins quarkus-1.9.0, wsdl2rest-0.0.15 (deprecated), fabric8-analytics-0.3.5, project-initializer-0.2.1 nboldt@redhat.com (55 seconds ago)
* 6b12cf4d - bump to new microprofile 0.3.0 nboldt@redhat.com (55 seconds ago)
* 1d190a0a - bump to cdt-gdb-vscode-0.0.92, intelephense-client-1.8.2, and vscode-clangd-0.1.15 nboldt@redhat.com (55 seconds ago)
* ba0901e5 - switch to equivalent versions of java8 and java11 from openvsx nboldt@redhat.com (82 seconds ago)
* 6ea0cf83 - bump to latest camel, camelk, and php-debug from openvsx nboldt@redhat.com (82 seconds ago)
* c352eb17 - chore: CRW-2662 update more plugins to newer versions vscode-openshift-connector-0.2.13, fabric8-analytics-0.2.1, go-0.23.0 nboldt@redhat.com (2 minutes ago)
* 0fcb8ad6 - CRW-2662 update theia plugins to latest versions from che-plugin-registry; switch to open-vsx files and /home/user/ instead of /home/jboss/ as udi image uses new home dir nboldt@redhat.com (2 minutes ago)

Change-Id: Id7e5d0fab45cde93eb5b531865ad74b4248b7b7c
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.