### PR TITLE
chore: add links.devWorkspaces field to the index.json

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
+++ b/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
@@ -29,7 +29,7 @@ do
 
     npm_config_yes=true npx @eclipse-che/che-theia-devworkspace-handler --devfile-url:"${devfile_url}" \
     --editor:eclipse/che-theia/latest \
-    --plugin-registry-url:https://redhat-developer.github.io/codeready-workspaces/che-plugin-registry/"${VERSION}"/"${arch}"/v3 \
+    --plugin-registry-url:https://redhat-developer.github.io/devspaces/che-plugin-registry/"${VERSION}"/"${arch}"/v3 \
     --output-file:"${dir}"devworkspace-che-theia-latest.yaml \
     "--project.${name}={{ DEVFILE_REGISTRY_URL }}/resources/v2/${name}.zip"
     clone_and_zip "${devfile_repo}" "${devfile_url##*/}" "$(pwd)/resources/v2/$name.zip"

--- a/dependencies/che-devfile-registry/build/scripts/index.sh
+++ b/dependencies/che-devfile-registry/build/scripts/index.sh
@@ -19,6 +19,12 @@ for meta in "${metas[@]}"; do
 
     # Ignore double quotes warning for yq expression
     # shellcheck disable=SC2016,SC2094
-    cat <<< "$(yq --arg metadir "${META_DIR}" '.links |= . + {self: "/\($metadir)/devfile.yaml" }' "${meta}")"  > "${meta}"
+    cat <<< "$(yq -y --arg metadir "${META_DIR}" '.links |= . + {self: "/\($metadir)/devfile.yaml" }' "${meta}")"  > "${meta}"
+    if [ "$(yq '.links.v2' "${meta}")" != "null" ]; then
+      # Ignore double quotes warning for yq expression
+      # shellcheck disable=SC2016,SC2094
+      cat <<< "$(yq -y --arg metadir "${META_DIR}" '.links.devWorkspaces |= . +
+      {"eclipse/che-theia/latest": "/\($metadir)/devworkspace-che-theia-latest.yaml"}' "${meta}")" > "${meta}"
+    fi
 done
 yq -s 'map(.)' "${metas[@]}"

--- a/dependencies/che-devfile-registry/versions.json
+++ b/dependencies/che-devfile-registry/versions.json
@@ -1,3 +1,3 @@
 {
-  "che-theia-devworkspace-handler": "0.0.1-1643111178"
+  "che-theia-devworkspace-handler": "0.0.1-1649678182"
 }


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
* Add `links.devWorkspaces` field to the `devfiles/index.json`.
* Update the plugin-registry GitHub pages link.
* Update `che-theia-devworkspace-handler` version.

New `devfiles/index.json`:
```JSON
{
  "displayName": "Java with JBoss EAP XP 3.0 Bootable Jar",
  "description": "Java stack with OpenJDK 11, Maven 3.6.3 and JBoss EAP XP 3.0 Bootable Jar",
  "tags": [
    "Java",
    "OpenJDK",
    "Maven",
    "EAP",
    "Microprofile",
    "EAP XP",
    "Bootable Jar",
    "UBI8"
  ],
  "icon": "[http://:/images/type-jboss.svg](http://images/type-jboss.svg)",
  "links": {
    "v2": "https://github.com/crw-samples/microprofile-quickstart-bootable/tree/devfilev2",
    "self": "[http://:/devfiles/00_java11-maven-microprofile-bootable/devfile.yaml](http://devfiles/00_java11-maven-microprofile-bootable/devfile.yaml)",
    "devWorkspaces": {
      "eclipse/che-theia/latest": "/devfiles/00_java11-maven-microprofile-bootable/devworkspace-che-theia-latest.yaml"
    }
  }
},
```

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2500
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
