### PR TITLE
chore:set and use RELATED_IMAGE envs for devworskpaces

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
@@ -59,7 +59,7 @@ function run_main() {
     sed -i "s|\"icon\": \"/images/|\"icon\": \"${PUBLIC_URL}/images/|" "$INDEX_JSON"
     sed -i "s|\"self\": \"/devfiles/|\"self\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
   else
-    if grep -q '{{ DEVFILE_REGISTRY_URL }}' "${devfiles[@]}" ${templates[@]}; then
+    if grep -q '{{ DEVFILE_REGISTRY_URL }}' "${devfiles[@]}" "${templates[@]}"; then
       echo "WARNING: environment variable 'CHE_DEVFILE_REGISTRY_URL' not configured" \
         "for an offline build of this registry. This may cause issues with importing" \
         "projects in a workspace."
@@ -135,7 +135,7 @@ function extract_and_use_related_images_env_variables_with_image_digest_info() {
       done
     fi
 
-    readarray -t devfiles < <(find "${DEVFILES_DIR}" -name 'devfile.yaml')
+    readarray -t devfiles < <(find "${DEVFILES_DIR}" -name 'devfile.yaml' -o -name 'devworkspace-*.yaml')
     for devfile in "${devfiles[@]}"; do
       readarray -t images < <(grep "image:" "${devfile}" | sed -r "s;.*image:[[:space:]]*'?\"?([._:a-zA-Z0-9-]*/?[._a-zA-Z0-9-]*/[._a-zA-Z0-9-]*(@sha256)?:?[._a-zA-Z0-9-]*)'?\"?[[:space:]]*;\1;")
       for image in "${images[@]}"; do

--- a/dependencies/che-devfile-registry/build/scripts/list_referenced_images.sh
+++ b/dependencies/che-devfile-registry/build/scripts/list_referenced_images.sh
@@ -16,7 +16,7 @@ CONTAINERS=""
 
 while IFS= read -r -d '' file; do
   CONTAINERS="${CONTAINERS} $(yq -r '..|.image?' "${file}" | grep -v "null" | sort | uniq)"
-done < <(find "$1" -name 'devfile.yaml' -print0)
+done < <(find "$1" \( -name 'devfile.yaml' -o -name 'devworkspace-*.yaml' \) -print0)
 
 CONTAINERS_UNIQ=()
 # shellcheck disable=SC2199


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
- Look at devworkspace-*.yaml files to collect used images which will be injected into the image with digest be crw-operator at build time
- Replace tag with digest in devworkspace-*.yaml files at runtime 


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2887
