### PR TITLE
CRW-2886 remove duplicate home dirs and...

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-gradle/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-gradle/devfile.yaml
@@ -22,7 +22,7 @@ components:
     image: registry.redhat.io/devspaces/udi-rhel8:3.0
     env:
       - name: GRADLE_USER_HOME
-        value: /home/jboss/.gradle
+        value: /home/user/.gradle
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
@@ -30,15 +30,15 @@ components:
       - name: JAVA_TOOL_OPTIONS
         value: $(JAVA_OPTS)
       - name: HOME
-        value: /home/jboss
+        value: /home/user
     memoryLimit: 640Mi
     volumes:
       - name: gradle
-        containerPath: /home/jboss/.gradle
+        containerPath: /home/user/.gradle
+    mountSources: true
     endpoints:
       - name: input-form-endpoint
         port: 8080
-    mountSources: true
 commands:
   - 
     name: 1. Build

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -142,8 +142,6 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
-        - name: gradle
-          path: /home/user/.gradle
     extension: https://github.com/redhat-developer/devspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-microprofile-0.1.1-48.vsix
   - id: redhat/quarkus-java11
     repository:
@@ -161,8 +159,6 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
-        - name: gradle
-          path: /home/user/.gradle
     extension: https://github.com/redhat-developer/devspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-quarkus-1.7.0-437.vsix
     metaYaml:
       skipDependencies:
@@ -274,14 +270,9 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 800m
       cpuRequest: 30m
-      env:
-        - name: GRADLE_HOME
-          value: /opt/gradle/
       volumeMounts:
         - name: m2
           path: /home/user/.m2
-        - name: gradle
-          path: /home/user/.gradle
     extension: https://github.com/redhat-developer/devspaces-vscode-extensions/releases/download/7.44-che-assets/java-0.82.0-369.vsix
     metaYaml:
       extraDependencies:


### PR DESCRIPTION
### What does this PR do?

CRW-2886 remove duplicate home dirs and GRADLE_HOME from che-plugin-registry/che-theia-plugins.yaml; use correct /home/user in devfile (which already defines GRADLE_USER_HOME env var

This change will align the contents of the DS plugin and devfile registies to what's done upstream in Che. 

Change-Id: I3701b76b363fb5e966e06f97d8cf7c43d4f2dce3
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.