### PR TITLE
chore: set INTERNAL_URL for devfile-registry and use it in generated …

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
@@ -30,6 +30,7 @@ REGISTRY=${CHE_DEVFILE_IMAGES_REGISTRY_URL}
 ORGANIZATION=${CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION}
 TAG=${CHE_DEVFILE_IMAGES_REGISTRY_TAG}
 PUBLIC_URL=${CHE_DEVFILE_REGISTRY_URL}
+INTERNAL_URL=${CHE_DEVFILE_REGISTRY_INTERNAL_URL}
 
 DEFAULT_DEVFILES_DIR="/var/www/html/devfiles"
 DEVFILES_DIR="${DEVFILES_DIR:-${DEFAULT_DEVFILES_DIR}}"
@@ -233,6 +234,12 @@ function update_container_image_references() {
     fi
   done
 }
+
+if [ -n "$INTERNAL_URL" ]; then
+  INTERNAL_URL=${INTERNAL_URL%/}
+  echo "Updating internal URL in files to ${INTERNAL_URL}"
+  sed -i "s|{{ INTERNAL_URL }}|${INTERNAL_URL}|" "${devfiles[@]}" "${metas[@]}" "${templates[@]}" "$INDEX_JSON"
+fi
 
 # do not execute the main function in unit tests
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]

--- a/dependencies/che-devfile-registry/build/dockerfiles/test_entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/test_entrypoint.sh
@@ -78,6 +78,7 @@ source "${script_dir}/entrypoint.sh"
 extract_and_use_related_images_env_variables_with_image_digest_info
 assertFileContentEquals "${DEVFILES_DIR}/external_images.txt" "${expected_externalImagesTxt}"
 
+#################################################################
 initTest "Should replace image references in devworkspace-che-theia-latest.yaml with RELATED_IMAGE env vars"
 
 externalImagesTxt=$(cat <<-END
@@ -134,6 +135,68 @@ echo "$devworkspace" > "${DEVFILES_DIR}/devworkspace-che-theia-latest.yaml"
 
 # NOTE: GIXDCNQK | base 32 -d = 2.16; GIXDCMIK | base 32 -d = 2.11 
 export RELATED_IMAGE_devspaces_theia_devfile_registry_image_GIXDCNIK='registry.redhat.io/devspaces/theia-rhel8@sha256:833f332f1e7f9a669b658bd6d1bf7f236c52ecf141a7006637fbda9f86fc5369'
+
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+extract_and_use_related_images_env_variables_with_image_digest_info
+assertFileContentEquals "${DEVFILES_DIR}/devworkspace-che-theia-latest.yaml" "${expected_devworkspace}"
+
+#######################################################################################
+initTest "Should replace INTERNAL_URL in devworkspace-che-theia-latest.yaml"
+
+devworkspace=$(cat <<-END
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  name: bash
+spec:
+  started: true
+  template:
+    components:
+      - name: tools
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+          memoryLimit: 3Gi
+      - name: theia-ide-bash
+        plugin:
+          kubernetes:
+            name: theia-ide-bash
+    projects:
+      - name: bash
+        zip:
+          location: '{{ INTERNAL_URL }}/resources/v2/bash.zip'
+  
+END
+)
+
+expected_devworkspace=$(cat <<-END
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  name: bash
+spec:
+  started: true
+  template:
+    components:
+      - name: tools
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+          memoryLimit: 3Gi
+      - name: theia-ide-bash
+        plugin:
+          kubernetes:
+            name: theia-ide-bash
+    projects:
+      - name: bash
+        zip:
+          location: 'http://devfile-registry.devspaces.svc:8080/resources/v2/bash.zip'
+END
+)
+
+echo "$devworkspace" > "${DEVFILES_DIR}/devworkspace-che-theia-latest.yaml"
+
+# NOTE: GIXDCNQK | base 32 -d = 2.16; GIXDCMIK | base 32 -d = 2.11 
+export CHE_DEVFILE_REGISTRY_INTERNAL_URL='http://devfile-registry.devspaces.svc:8080'
 
 # shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"

--- a/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
+++ b/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
@@ -31,7 +31,7 @@ do
     --editor:eclipse/che-theia/latest \
     --plugin-registry-url:https://redhat-developer.github.io/devspaces/che-plugin-registry/"${VERSION}"/"${arch}"/v3 \
     --output-file:"${dir}"devworkspace-che-theia-latest.yaml \
-    "--project.${name}={{ DEVFILE_REGISTRY_URL }}/resources/v2/${name}.zip"
+    "--project.${name}={{ INTERNAL_URL }}/resources/v2/${name}.zip"
     clone_and_zip "${devfile_repo}" "${devfile_url##*/}" "$(pwd)/resources/v2/$name.zip"
   fi
 done


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Set INTERNAL_URL for devfile-registry and use it in generated devworkspaces

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2908

