### PR TITLE
fix: don't use spaces in the project's location

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
@@ -244,7 +244,7 @@ function set_internal_url() {
   if [ -n "$INTERNAL_URL" ]; then
     INTERNAL_URL=${INTERNAL_URL%/}
     echo "Updating internal URL in files to ${INTERNAL_URL}"
-    sed -i "s|{{ INTERNAL_URL }}|${INTERNAL_URL}|" "${devfiles[@]}" "${metas[@]}" "${templates[@]}" "$INDEX_JSON"
+    sed -i "s|{{INTERNAL_URL}}|${INTERNAL_URL}|" "${devfiles[@]}" "${metas[@]}" "${templates[@]}" "$INDEX_JSON"
   fi
 }
 

--- a/dependencies/che-devfile-registry/build/dockerfiles/test_entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/test_entrypoint.sh
@@ -164,7 +164,7 @@ spec:
     projects:
       - name: bash
         zip:
-          location: '{{ INTERNAL_URL }}/resources/v2/bash.zip'
+          location: '{{INTERNAL_URL}}/resources/v2/bash.zip'
 END
 )
 

--- a/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
+++ b/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
@@ -31,7 +31,7 @@ do
     --editor:eclipse/che-theia/latest \
     --plugin-registry-url:https://redhat-developer.github.io/devspaces/che-plugin-registry/"${VERSION}"/"${arch}"/v3 \
     --output-file:"${dir}"devworkspace-che-theia-latest.yaml \
-    "--project.${name}={{ INTERNAL_URL }}/resources/v2/${name}.zip"
+    "--project.${name}={{INTERNAL_URL}}/resources/v2/${name}.zip"
     clone_and_zip "${devfile_repo}" "${devfile_url##*/}" "$(pwd)/resources/v2/$name.zip"
   fi
 done


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Skip spaces in the project location in devworkspace templates

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2908