### PR TITLE
chore: use internal url in plugin meta.yaml to download vsx

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -23,6 +23,7 @@ set -e
 REGISTRY=${CHE_SIDECAR_CONTAINERS_REGISTRY_URL}
 ORGANIZATION=${CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION}
 TAG=${CHE_SIDECAR_CONTAINERS_REGISTRY_TAG}
+INTERNAL_URL=${CHE_PLUGIN_REGISTRY_INTERNAL_URL}
 
 DEFAULT_METAS_DIR="/var/www/html/v3"
 METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
@@ -42,6 +43,8 @@ function run_main() {
     extract_and_use_related_images_env_variables_with_image_digest_info
 
     update_container_image_references
+
+    update_extension_vsx_references
 
     # For testing, the images used for the che-theia, theia runtime, and machine-exec
     # plugins can be overridden via the environment variables
@@ -223,6 +226,15 @@ function update_container_image_references() {
     fi
     done
 
+}
+
+function update_extension_vsx_references() {
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml' -o -name 'devfile.yaml' -o -name 'che-theia-plugin.yaml')
+    if [ -n "$INTERNAL_URL" ]; then
+        INTERNAL_URL=${INTERNAL_URL%/}
+        echo "Updating relative:extension in files to ${INTERNAL_URL}"
+        sed -i "s|relative:extension|${INTERNAL_URL}|" "${metas[@]}"
+    fi
 }
 
 # do not execute the main function in unit tests

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -70,7 +70,6 @@ function run_main() {
     fi
 
     exec "${@}"
-
 }
 
 function extract_and_use_related_images_env_variables_with_image_digest_info() {

--- a/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
@@ -798,3 +798,68 @@ export RELATED_IMAGE_devspaces_udi_plugin_registry_image_GIXDCNQK='registry.redh
 source "${script_dir}/entrypoint.sh"
 extract_and_use_related_images_env_variables_with_image_digest_info
 assertFileContentEquals "${METAS_DIR}/external_images.txt" "${expected_externalImagesTxt}"
+
+#################################################################
+initTest "Should replace relative:extension with internal URL in che-theia-plugin.yaml "
+
+cheTheiaPluginYaml=$(cat <<-END
+schemaVersion: 1.0.0
+metadata:
+  id: redhat/java11
+  publisher: redhat
+  name: java11
+  version: latest
+  displayName: Language Support for Java(TM) by Red Hat
+  description: 'Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...'
+  repository: 'https://github.com/redhat-developer/vscode-java'
+  categories:
+    - Programming Languages
+    - Linters
+    - Formatters
+    - Snippets
+  icon: /images/redhat-java-icon.png
+sidecar:
+  image: 'registry.redhat.io/devspaces/udi-rhel8:2.16'
+  name: vscode-java
+  memoryLimit: 1500Mi
+  cpuLimit: 500m
+  cpuRequest: 30m
+extensions:
+  - 'relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix'
+END
+)
+expected_cheTheiaPluginYaml=$(cat <<-END
+schemaVersion: 1.0.0
+metadata:
+  id: redhat/java11
+  publisher: redhat
+  name: java11
+  version: latest
+  displayName: Language Support for Java(TM) by Red Hat
+  description: 'Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...'
+  repository: 'https://github.com/redhat-developer/vscode-java'
+  categories:
+    - Programming Languages
+    - Linters
+    - Formatters
+    - Snippets
+  icon: /images/redhat-java-icon.png
+sidecar:
+  image: 'registry.redhat.io/devspaces/udi-rhel8:2.16'
+  name: vscode-java
+  memoryLimit: 1500Mi
+  cpuLimit: 500m
+  cpuRequest: 30m
+extensions:
+  - 'http://che-plugin-registry/v3/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix'
+END
+)
+
+echo "$cheTheiaPluginYaml" > "${METAS_DIR}/che-theia-plugin.yaml"
+
+export CHE_PLUGIN_REGISTRY_INTERNAL_URL=http://che-plugin-registry/v3
+
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+update_extension_vsx_references
+assertFileContentEquals "${METAS_DIR}/che-theia-plugin.yaml" "${expected_cheTheiaPluginYaml}"


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Replaces `relative:extension` with plugin-registry internal URL at runtime in the plugin registry container

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2973