### PR TITLE
fix: remove redundant docker pull from GA

### DIFF
--- a/.github/workflows/plugin-registry-build.yaml
+++ b/.github/workflows/plugin-registry-build.yaml
@@ -65,7 +65,6 @@ jobs:
 
       - name: image-build
         run: |
-          docker pull quay.io/devspaces/pluginregistry-rhel8:next-gh-action
           BUILDER=docker SKIP_FORMAT=true SKIP_LINT=true SKIP_TEST=true ./build.sh --tag next-gh-action --offline
 
       - name: push plugin registry image

--- a/.github/workflows/plugin-registry-pr-check-build.yaml
+++ b/.github/workflows/plugin-registry-pr-check-build.yaml
@@ -67,7 +67,6 @@ jobs:
         export SKIP_FORMAT=true
         export SKIP_LINT=true
         export SKIP_TEST=true
-        docker pull quay.io/devspaces/pluginregistry-rhel8:next-gh-action
         BUILDER=docker ./build.sh --tag pr-check --offline
         EXPORTED_FOLDER=/var/www/html/v3
         ls -la output/


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Avoid cloning `quay.io/devspaces/pluginregistry-rhel8:next-gh-action` image before the image build to fix GitHub action, it seems this image is not needed for the build process.