### PR TITLE
fix: remove meta.yaml if devfile.yaml.${arch} exists

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/swap_yamlfiles.sh
+++ b/dependencies/che-devfile-registry/build/scripts/swap_yamlfiles.sh
@@ -18,18 +18,11 @@ yamlfiles=$("$SCRIPT_DIR"/list_yaml.sh "$YAML_ROOT")
 
 # shellcheck disable=SC2086
 for yamlfile in $yamlfiles ; do
-  if [[ -e ${yamlfile}.${arch} ]] ; then
-      mv ${yamlfile} ${yamlfile}.orig
-      mv ${yamlfile}.${arch} ${yamlfile}
-      echo "[INFO] swapped to $arch version of ${yamlfile}.${arch}"
-  fi
-
-  # remove empty
-  if [[ ! -s ${yamlfile} ]] ; then
+  if [[ -e "$(dirname $yamlfile)/devfile.yaml.${arch}" ]] ; then
     mv ${yamlfile} ${yamlfile}.removed
     if [[ -e "$(dirname $yamlfile)/meta.yaml" ]] ; then
       mv "$(dirname $yamlfile)/meta.yaml" "$(dirname $yamlfile)/meta.yaml.removed"
     fi
-    echo "[INFO] removed empty yamlfile ${yamlfile}"
+    echo "[INFO] removed yamlfile ${yamlfile}"
   fi
 done


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Marks meta.yaml as removed if devfile folder contains devfile.yaml.**arch** file. Where **arch** could be ppc64le or s390x.
When meta.yaml is marked as removed, the devfile should not be shown on the Create workspace view.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3034