### PR TITLE
fix: collect theia plugin deps from correct directory

### DIFF
--- a/product/manifest/get-3rd-party-deps-theia.sh
+++ b/product/manifest/get-3rd-party-deps-theia.sh
@@ -87,7 +87,7 @@ pushd "$TMPDIR" >/dev/null || exit
 		podman pull quay.io/devspaces/theia-rhel8:${CRW_VERSION}
 
 		# copy plugin directories into the filesystem, in order to execute yarn commands to obtain yarn.lock file, and list dependencies from it
-		"${TMPDIR}/containerExtract.sh" quay.io/devspaces/theia-rhel8:${CRW_VERSION} --tar-flags home/theia/plugins/**
+		"${TMPDIR}/containerExtract.sh" quay.io/devspaces/theia-rhel8:${CRW_VERSION} --tar-flags default-theia-plugins/**
 		find /tmp/quay.io-devspaces-theia-rhel8-${CRW_VERSION}-* -path '*extension/node_modules' -exec sh -c "cd {}/.. && yarn --silent && yarn list --depth=0" \; >> ${MANIFEST_FILE}.plugin-extensions
 		sed \
 				-e '/Done in/d' \


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Some time ago, the location of theia plugins in the container has changed:
https://github.com/eclipse-che/che-theia/pull/1286/files

So manifest collection script should reference the current 'default-theia-plugins' in the root of Theia container

### What issues does this PR fix or reference?
part of https://issues.redhat.com/browse/CRW-3069

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
