### PR TITLE
fix: set correct id for vscode-quarks plugin

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -143,10 +143,12 @@ plugins:
         - name: m2
           path: /home/user/.m2
     extension: https://github.com/redhat-developer/devspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-microprofile-0.1.1-48.vsix
-  - id: redhat/quarkus-java11
+  - id: redhat/vscode-quarkus
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'
       revision: v1.7.0
+    aliases:
+      - redhat/quarkus-java11
     preferences:
       java.server.launchMode: Standard
     sidecar:


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Update id for Quarkus plugin accordingly to upstream https://github.com/eclipse-che/che-plugin-registry/blob/main/che-theia-plugins.yaml#L222 

### What issues does this PR fix or reference?
Quarkus plugins cannot be installed in Quarkus base workspace
https://issues.redhat.com/browse/CRW-2993
