### PR TITLE
chore: increase idle timeout to 30 minutes

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -126,7 +126,7 @@ editors:
             - '--url'
             - '127.0.0.1:3333'
             - '--idle-timeout'
-            - '15m'
+            - '30m'
           endpoints:
             - name: terminal
               targetPort: 3333


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Increases idle timeout to 30 minutes in workspaces that use Theia editor

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3154
