### PR TITLE
chore: remove `--idle-timeout` for che-theia editor since timeout is read from environment variable

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -125,8 +125,6 @@ editors:
             - /go/bin/che-machine-exec
             - '--url'
             - '127.0.0.1:3333'
-            - '--idle-timeout'
-            - '30m'
           endpoints:
             - name: terminal
               targetPort: 3333


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
This PR is meant for Dev Spaces 3.2.

Removes the --idle-timeout from the theia editor since the idle timeout is now being [read as an environment variable](https://github.com/eclipse-che/che-machine-exec/pull/208) set by [Che + DWO](https://github.com/eclipse-che/che-operator/pull/1443)

### What issues does this PR fix or reference?
This change is part of https://github.com/eclipse/che/issues/21390

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
