### PR TITLE
fix: use 3.1 tag for Code editor

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -284,7 +284,7 @@ editors:
     components:
       - name: che-code-injector
         container:
-          image: 'quay.io/devspaces/code-rhel8:3.2'
+          image: 'quay.io/devspaces/code-rhel8:3.1'
           command: ["/entrypoint-init-container.sh"]
           volumeMounts:
             - name: checode
@@ -295,7 +295,7 @@ editors:
           cpuRequest: 30m
       - name: che-code-runtime-description
         container:
-          image: 'quay.io/devspaces/udi-rhel8:3.2'
+          image: 'quay.io/devspaces/udi-rhel8:3.1'
           memoryLimit: 1024Mi
           memoryRequest: 256Mi
           cpuLimit: 500m


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use 3.1 tag of images in the Che code editor

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2288
