### PR TITLE
fix: CRW-3177 don't use quay.io images in...

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -284,7 +284,7 @@ editors:
     components:
       - name: che-code-injector
         container:
-          image: 'quay.io/devspaces/code-rhel8:3.1'
+          image: 'registry.redhat.io/devspaces/code-rhel8:3.1'
           command: ["/entrypoint-init-container.sh"]
           volumeMounts:
             - name: checode
@@ -295,7 +295,7 @@ editors:
           cpuRequest: 30m
       - name: che-code-runtime-description
         container:
-          image: 'quay.io/devspaces/udi-rhel8:3.1'
+          image: 'registry.redhat.io/devspaces/udi-rhel8:3.1'
           memoryLimit: 1024Mi
           memoryRequest: 256Mi
           cpuLimit: 500m


### PR DESCRIPTION
### What does this PR do?

fix: CRW-3177 don't use quay.io images in stable branch! this causes duplicate references in the CSV for quay.io/devspaces/udi-rhel8:3.1 and registry.redhat.io/devspaces/udi-rhel8:3.1; also we should not have quay references for any containers in a stable branch -- only registry.redhat.io/devspaces

Change-Id: I3b211ba9d08a5c3822f9771c9cf217b0d2e30b21
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.