### PR TITLE
feat: update fabric8-analytics plugin to 0.3.6

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -167,7 +167,7 @@ plugins:
         - vscjava/vscode-java-test
   - repository:
       url: 'https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension'
-      revision: 0.2.1
+      revision: 0.3.6
     aliases:
       - redhat/dependency-analytics
     sidecar:
@@ -177,7 +177,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.2.1/fabric8-analytics-0.2.1.vsix
+    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.3.6/fabric8-analytics-0.3.6.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-project-initializer'
       revision: v0.0.10


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates fabric8-analytics plugin to 0.3.6

[screencast-nimbus-capture-2022.08.11-12_27_42.webm](https://user-images.githubusercontent.com/1271546/184846431-f8bc2632-6848-4398-9de5-0ced916ce9e1.webm)

**NOTES:**

_The plugin has a problem in Che-Theia editor, when generate the report by using project tree at the first time. To workaround this problem try to generate the report by using a command: click F1 and select Dependency Analytics: Stack Report... Then it will be possible to execute the command from the project tree as well._

![Screenshot from 2022-08-15 20-45-13](https://user-images.githubusercontent.com/1271546/184848352-89e09bf4-af5c-4bf2-a49e-011317bbd65c.png)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2208

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
