### PR TITLE
CRW-3294 add --icsp flag to allow setting a...

### DIFF
--- a/product/installDevSpacesFromLatestIIB.sh
+++ b/product/installDevSpacesFromLatestIIB.sh
@@ -35,6 +35,12 @@ DWO_VERSION="" # by default, install from latest release
 CHANNEL_DWO="fast"
 CHANNEL_DS="stable"
 
+# default ICSP to use to resolve unreleased images
+# if using --fast or --quay flag, this will be changed to quay.io
+# if using --brew flag, this will be changed to brew.registry.redhat.io
+# if you want your own registry here, use --icsp flag to specify it
+ICSP_FLAG=""
+
 errorf() {
   echo -e "${RED}Error: $1${NC}"
 }
@@ -86,6 +92,9 @@ Options:
                       : * quay.io/devspaces/iib:3.3-v4.11-987654-x86_64 [public], or 
                       : * quay.io/devspaces/iib:next-v4.10-ppc64le [public]
   --quay, --fast      : Install from quay.io/devspaces/iib:<DS_VERSION>-v4.yy-<OS_ARCH> (detected OCP version + arch) from fast channel
+                      : Resolve images from quay.io using ImageContentSourcePolicy
+  --brew              : Resolve images from brew.registry.redhat.io using ImageContentSourcePolicy
+  --icsp <REGISTRY>   : Resolve images from specified registry URL using ImageContentSourcePolicy
   --dsc               : Optional. To install with dsc, use '--dsc 3.1.0-CI' or '--dsc 3.0.0-GA'
                       : Use '--dsc local' to search PATH for installed dsc, or use '--dsc /path/to/dsc/bin/'
   --delete-before     : Before installing with dsc, delete using server:delete -y. Will not delete namespaces.
@@ -196,7 +205,9 @@ while [[ "$#" -gt 0 ]]; do
       fi; shift 1;;
     '--iib-dwo') IIB_DWO="$2"; shift 1;;
     '--iib-ds') IIB_DS="$2"; shift 1;;
-    '--quay'|'--fast') IIB_DS="quay.io/devspaces/iib"; CHANNEL_DS="fast"; CHANNEL_DWO="fast";;
+    '--quay'|'--fast') IIB_DS="quay.io/devspaces/iib"; CHANNEL_DS="fast"; CHANNEL_DWO="fast"; ICSP_FLAG="--icsp quay.io";;
+    '--brew') ICSP_FLAG="--icsp brew.registry.redhat.io";;
+    '--icsp') ICSP_FLAG="--icsp $2"; shift 1;;
     '--delete-before') DELETE_BEFORE="true";;
     '--get-url') GET_URL="true";;
     '--no-get-url') GET_URL="false";;
@@ -215,6 +226,7 @@ echo "Detected OpenShift: v$OPENSHIFT_VER $OPENSHIFT_ARCH"
 if [[ $DWO_VERSION ]]; then
   if [[ ! $IIB_DWO ]] && [[ $DWO_VERSION ]]; then # compute the latest IIB for the DWO version passed in
     IIB_DWO=$("$SCRIPT_DIR"/getLatestIIBs.sh --dwo -t "$DWO_VERSION" -o "$OPENSHIFT_VER" -q)
+    if [[ ! $ICSP_FLAG ]]; then ICSP_FLAG="--icsp brew.registry.redhat.io"; fi
     if [[ $IIB_DWO ]]; then
       echo "[INFO] Found latest Dev Workspace Operator IIB $IIB_DWO - installing from $CHANNEL_DWO channel..."
     else
@@ -231,11 +243,12 @@ if [[ $IIB_DWO ]]; then
     --iib "$IIB_DWO" \
     --install-operator "devworkspace-operator" \
     --channel "$CHANNEL_DWO" \
-    --namespace "$OLM_NAMESPACE"
+    --namespace "$OLM_NAMESPACE" ${ICSP_FLAG}
 fi
 
 if [[ ! $IIB_DS ]]; then
-  IIB_DS=$("$SCRIPT_DIR"/getLatestIIBs.sh   --ds -t "$DS_VERSION"  -o "$OPENSHIFT_VER" -q)
+  IIB_DS=$("$SCRIPT_DIR"/getLatestIIBs.sh --ds -t "$DS_VERSION"  -o "$OPENSHIFT_VER" -q)
+  if [[ ! $ICSP_FLAG ]]; then ICSP_FLAG="--icsp brew.registry.redhat.io"; fi
   if [[ $IIB_DS ]]; then 
     echo "[INFO] Found latest Dev Spaces IIB $IIB_DS - installing from $CHANNEL_DS channel..."
   else
@@ -254,7 +267,7 @@ fi
   --iib "$IIB_DS" \
   --install-operator "devspaces" \
   --channel "$CHANNEL_DS" \
-  --namespace "$OLM_NAMESPACE"
+  --namespace "$OLM_NAMESPACE" ${ICSP_FLAG}
 
 elapsed=0
 inc=3


### PR DESCRIPTION
### What does this PR do?

[CRW-3294](https://issues.redhat.com/projects/CRW/issues/CRW-3294) add `--icsp` flag to allow setting a non-standard mirror 
 / container registry against which to resolve images; 

allows installation of unreleased DS 3.x CI images from reg.rh.io by looking at quay.io instead;

NOTE: as of this change, the default brew.registry.redhat.io ICSP won't be turned on by default unless we're searching for the latestIIBs. To install from a SPECIFIC IIB using brew.registry ICSP, use new `--brew` flag.

If using `--fast` or `--quay` will use quay.io for ICSP by default.

Change-Id: Ice9976b09afa1c428f64ab1987007892326f81aa
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.