### PR TITLE
chore: run openvsx-server and postgres from entrypoint.sh only

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -119,7 +119,7 @@ COPY /build/dockerfiles/entrypoint.sh /mnt/rootfs/usr/local/bin/
 RUN chmod g+rwx -R /mnt/rootfs/var/www/html/v3
 
 # Delete files that should not be copied into the final image
-RUN rm -rf /mnt/rootfs/etc/hosts
+RUN rm -rf /mnt/rootfs/etc/hosts /usr/share/i18n/ /usr/lib/locale
 
 # Use ubi8-minimal image and then copy ubi fs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
@@ -144,16 +144,6 @@ ENV LC_ALL=en_US.UTF-8 \
 ARG DS_BRANCH=devspaces-3-rhel-8
 ENV DS_BRANCH=${DS_BRANCH}
 
-RUN /usr/pgsql-13/bin/initdb && \
-    # Add all vsix files to the database
-    /usr/local/bin/import_vsix.sh && \
-    # add permissions for anyuserid
-    chgrp -R 0 /var/lib/pgsql/13/data/database && \
-    #cleanup postgresql pid
-    rm /var/lib/pgsql/13/data/database/postmaster.pid && \
-    rm /var/run/postgresql/.s.PGSQL* && \
-    rm /tmp/.s.PGSQL* && \
-    chmod -R g+rwX /var/lib/pgsql/13/data/database && mv /var/lib/pgsql/13/data/database /var/lib/pgsql/13/data/old
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # append Brew metadata here

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -82,12 +82,8 @@ function run_main() {
     
     # start only if wanted
     if [ "${START_OPENVSX}" == "true" ]; then
-      # change permissions
-      cp -r /var/lib/pgsql/13/data/old /var/lib/pgsql/13/data/database
-      rm -rf /var/lib/pgsql/13/data/old
-
-      # start postgres and openvsx
-      /usr/local/bin/start_services.sh
+      /usr/pgsql-13/bin/initdb
+      /usr/local/bin/import_vsix.sh
     fi
 
     # start httpd

--- a/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
@@ -45,6 +45,3 @@ done;
 
 # disable the personal access token
 psql -c "UPDATE personal_access_token SET active = false;"
-
-# cleanup
-rm -rf /openvsx-server/vsix


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Tying to a Brew build. These changes to avoid running openvsx server application and postgresql during the docker build.
All initialization logic was moved to the entrypoint.sh

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3295

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
