### PR TITLE
use regex to better match source image...

### DIFF
--- a/product/copyImageToQuay.sh
+++ b/product/copyImageToQuay.sh
@@ -55,15 +55,15 @@ for image in $images; do
     fi
     TAG=${image##*:}
     REGISTRYPRE=${IMG%%/*}/
-    if [[ $IMG == *"rh-osbs/"* ]]; then REGISTRYPRE="${REGISTRYPRE}rh-osbs/"; fi
+    if [[ $IMG =~ .+(rh-osbs/|devworkspace/|devspaces/).+ ]]; then REGISTRYPRE="${REGISTRYPRE}${BASH_REMATCH[1]}"; fi
     URLfrag=${image#*/}
 
     QUAYDEST="${URLfrag}"; 
     # # special case for the operator and bundle images, which don't follow the same pattern in osbs as quay
     if [[ $URLfrag == *"devworkspace"* ]]; then
-        if [[ ${QUAYDEST} == *"project-clone:"* ]]; then QUAYDEST="devworkspace/devworkspace-project-clone-rhel8:${TAG}"; fi
-        if [[ ${QUAYDEST} == *"operator-bundle:"* ]]; then QUAYDEST="devworkspace/devworkspace-operator-bundle:${TAG}"; fi
-        if [[ ${QUAYDEST} == *"operator:"* ]];        then QUAYDEST="devworkspace/devworkspace-rhel8-operator:${TAG}"; fi
+        if [[ ${QUAYDEST} =~ .*(devworkspace-|)project-clone(-rhel8|):.+ ]];   then QUAYDEST="devworkspace/devworkspace-project-clone-rhel8:${TAG}"; fi
+        if [[ ${QUAYDEST} =~ .*(devworkspace-|)operator-bundle:.+ ]];          then QUAYDEST="devworkspace/devworkspace-operator-bundle:${TAG}"; fi
+        if [[ ${QUAYDEST} =~ .*(devworkspace-|)(rhel8-|)operator:.+ ]];        then QUAYDEST="devworkspace/devworkspace-rhel8-operator:${TAG}"; fi
     elif [[ $URLfrag == *"devspaces"* ]]; then
         if [[ ${QUAYDEST} == *"/operator-bundle:"* ]]; then QUAYDEST="devspaces/devspaces-operator-bundle:${TAG}"; fi
         if [[ ${QUAYDEST} == *"/operator:"* ]];        then QUAYDEST="devspaces/devspaces-rhel8-operator:${TAG}"; fi


### PR DESCRIPTION
### What does this PR do?

use regex to better match source image options when copying DWO

Change-Id: I18701d432d707ddf132b2c73f8a2a99b2537c58a
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.