### PR TITLE
chore: improve list of vsix to use version and download link

### DIFF
--- a/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
@@ -6,42 +6,52 @@ set -o pipefail
 # pull vsix from OpenVSX
 mkdir -p /tmp/vsix
 openVsxSyncFileContent=$(cat "/openvsx-server/openvsx-sync.json")
-listOfVsixes=$(echo "${openVsxSyncFileContent}" | jq -r ".[]")
+numberOfExtensions=$(echo "${openVsxSyncFileContent}" | jq ". | length")
 IFS=$'\n' 
 
-for vsixFullName in $listOfVsixes; do
+for i in $(seq 0 "$((numberOfExtensions - 1))"); do
+    vsixFullName=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].id")
+    vsixVersion=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].version")
+    vsixDownloadLink=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].download")
+
     # extract from the vsix name the publisher name which is the first part of the vsix name before dot
     vsixPublisher=$(echo "${vsixFullName}" | cut -d '.' -f 1)
 
     # replace the dot by / in the vsix name
     vsixName=$(echo "${vsixFullName}" | sed 's/\./\//g')
 
-    # grab metadata for the vsix file
-    vsixMetadata=$(curl -sL "https://open-vsx.org/api/${vsixName}/latest")
-
-    # check there is no error field in the metadata
-    if [[ $(echo "${vsixMetadata}" | jq -r ".error") != null ]]; then
-        echo "Error while getting metadata for ${vsixFullName}"
-        echo "${vsixMetadata}"
-        exit 1
-    fi
-
-    # grab the version field from metadata
-    vsixVersion=$(echo "${vsixMetadata}" | jq -r '.version')
-
-    # extract the download link from the json metadata
-    vsixDownloadLink=$(echo "${vsixMetadata}" | jq -r '.files.download')
-    # get linux-x64 download link
-    vsixLinux64DownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."linux-x64"')
-    if [[ $vsixLinux64DownloadLink != null ]]; then
-        vsixDownloadLink=$vsixLinux64DownloadLink
+    # if download wasn't set, try to fetch from opnevsx.org
+    if [[ $vsixDownloadLink == null ]]; then
+        # grab metadata for the vsix file
+        # if version wasn't set, use latest
+        if [[ $vsixVersion == null ]]; then
+            vsixMetadata=$(curl -sL "https://open-vsx.org/api/${vsixName}/latest")
+            
+            # if version wasn't set in json, grab it from metadata and add it into the file
+            vsixVersion=$(echo "${vsixMetadata}" | jq -r '.version')
+            jq --argjson i "$i" --arg version "$vsixVersion" '.[$i] += { "version": $version }' /openvsx-server/openvsx-sync.json > tmp.json
+            mv tmp.json /openvsx-server/openvsx-sync.json
+        else
+            vsixMetadata=$(curl -sL "https://open-vsx.org/api/${vsixName}/${vsixVersion}")
+        fi 
+        # check there is no error field in the metadata
+        if [[ $(echo "${vsixMetadata}" | jq -r ".error") != null ]]; then
+            echo "Error while getting metadata for ${vsixFullName}"
+            echo "${vsixMetadata}"
+            exit 1
+        fi
+        
+        # extract the download link from the json metadata
+        vsixDownloadLink=$(echo "${vsixMetadata}" | jq -r '.files.download')
+        # get linux-x64 download link
+        vsixLinux64DownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."linux-x64"')
+        if [[ $vsixLinux64DownloadLink != null ]]; then
+            vsixDownloadLink=$vsixLinux64DownloadLink
+        fi
     fi
 
     echo "Downloading ${vsixDownloadLink} into ${vsixPublisher} folder..."
     vsixFilename="/tmp/vsix/${vsixFullName}-${vsixVersion}.vsix"
     # download the latest vsix file in the publisher directory
     curl -sL "${vsixDownloadLink}" -o "${vsixFilename}"
-
-    # shellcheck disable=SC2016
-    sed -i "s/\"$vsixFullName\"/\"$vsixFullName:$vsixVersion\"/g" /openvsx-server/openvsx-sync.json
 done;

--- a/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
@@ -20,13 +20,13 @@ containsElement () { for e in "${@:2}"; do [[ "$e" = "$1" ]] && return 0; done; 
 # pull vsix from OpenVSX
 mkdir -p /tmp/vsix
 openVsxSyncFileContent=$(cat "/openvsx-server/openvsx-sync.json")
-listOfVsixes=$(echo "${openVsxSyncFileContent}" | jq -r ".[]")
+numberOfExtensions=$(echo "${openVsxSyncFileContent}" | jq ". | length")
 listOfPublishers=()
 IFS=$'\n' 
 
-for extension in $listOfVsixes; do
-    vsixFullName=${extension%:*}
-    vsixVersion=${extension##*:}
+for i in $(seq 0 "$((numberOfExtensions - 1))"); do
+    vsixFullName=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].id")
+    vsixVersion=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].version")
     # extract from the vsix name the publisher name which is the first part of the vsix name before dot
     vsixPublisher=$(echo "${vsixFullName}" | cut -d '.' -f 1)
 

--- a/dependencies/che-plugin-registry/openvsx-sync.json
+++ b/dependencies/che-plugin-registry/openvsx-sync.json
@@ -1,44 +1,129 @@
 [
-    "donjayamanne.githistory",
-    "vscode.github-authentication",
-    "github.vscode-pull-request-github",
-    "ms-vscode.js-debug",
-    "vscode.typescript-language-features",
-    "llvm-vs-code-extensions.vscode-clangd",
-    "eclipse-cdt.cdt-gdb-vscode",
-    "bmewburn.vscode-intelephense-client",
-    "ms-python.python",
-    "golang.go",
-    "redhat.vscode-yaml",
-    "ms-kubernetes-tools.vscode-kubernetes-tools",
-    "redhat.java",
-    "vscjava.vscode-java-debug",
-    "vscjava.vscode-java-test",
-    "redhat.vscode-microprofile",
-    "redhat.vscode-quarkus",
-    "redhat.fabric8-analytics",
-    "redhat.project-initializer",
-    "redhat.vscode-redhat-account",
-    "redhat.vscode-openshift-connector",
-    "felixfbecker.php-debug",
-    "redhat.vscode-xml",
-    "muhammad-sammy.csharp",
-    "sonarsource.sonarlint-vscode",
-    "vscode.git-base",
-    "vscode.git",
-    "dbaeumer.vscode-eslint",
-    "redhat.vscode-commons",
-    "redhat.vscode-tekton-pipelines",
-    "atlassian.atlascode",
-    "JFrog.jfrog-vscode-extension",
-    "SonatypeCommunity.vscode-iq-plugin",
-    "GitLab.gitlab-workflow",
-    "timonwong.shellcheck",
-    "redhat.ansible",
-    "vscode.npm",
-    "esbenp.prettier-vscode",
-    "ms-toolsai.jupyter",
-    "ms-toolsai.jupyter-renderers",
-    "ms-toolsai.jupyter-keymap",
-    "eamodio.gitlens"
+    {
+        "id": "donjayamanne.githistory"
+    },
+    {
+        "id": "vscode.github-authentication"
+    },
+    {
+        "id": "github.vscode-pull-request-github"
+    },
+    {
+        "id": "ms-vscode.js-debug"
+    },
+    {
+        "id": "vscode.typescript-language-features"
+    },
+    {
+        "id": "llvm-vs-code-extensions.vscode-clangd"
+    },
+    {
+        "id": "eclipse-cdt.cdt-gdb-vscode"
+    },
+    {
+        "id": "bmewburn.vscode-intelephense-client"
+    },
+    {
+        "id": "ms-python.python"
+    },
+    {
+        "id": "golang.go"
+    },
+    {
+        "id": "redhat.vscode-yaml"
+    },
+    {
+        "id": "ms-kubernetes-tools.vscode-kubernetes-tools"
+    },
+    {
+        "id": "redhat.java",
+        "version": "1.12.0"
+    },
+    {
+        "id": "vscjava.vscode-java-debug"
+    },
+    {
+        "id": "vscjava.vscode-java-test"
+    },
+    {
+        "id": "redhat.vscode-microprofile"
+    },
+    {
+        "id": "redhat.vscode-quarkus"
+    },
+    {    
+        "id": "redhat.fabric8-analytics"
+    },
+    {
+        "id": "redhat.project-initializer"
+    },
+    {
+        "id": "redhat.vscode-redhat-account"
+    },
+    {
+        "id": "redhat.vscode-openshift-connector"
+    },
+    {
+        "id": "felixfbecker.php-debug"
+    },
+    {
+        "id": "redhat.vscode-xml"
+    },
+    {
+        "id": "muhammad-sammy.csharp"
+    },
+    {
+        "id": "sonarsource.sonarlint-vscode"
+    },
+    {
+        "id": "vscode.git-base"
+    },
+    {
+        "id": "vscode.git"
+    },
+    {
+        "id": "dbaeumer.vscode-eslint"
+    },
+    {
+        "id": "redhat.vscode-commons"
+    },
+    {
+        "id": "redhat.vscode-tekton-pipelines"
+    },
+    {
+        "id": "atlassian.atlascode"
+    },
+    {
+        "id": "JFrog.jfrog-vscode-extension"
+    },
+    {
+        "id": "SonatypeCommunity.vscode-iq-plugin"
+    },
+    {
+        "id": "GitLab.gitlab-workflow"
+    },
+    {
+        "id": "timonwong.shellcheck"
+    },
+    {
+        "id": "redhat.ansible"
+    },
+    {
+        "id": "vscode.npm"
+    },
+    {
+        "id": "esbenp.prettier-vscode"
+    },
+    {
+        "id": "ms-toolsai.jupyter"
+    },
+    {
+        "id": "ms-toolsai.jupyter-renderers"
+    },
+    {
+        "id": "ms-toolsai.jupyter-keymap"
+    },
+    {
+        "id": "eamodio.gitlens"
+    }
 ]


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Improve list of vsix files to be published in local openvsx registry. With these changes the extension could be described with this  schema:
```
{
  "id": "publisher.name" -- required,
  "download": "url_to_downlod_vsix" -- optional,
  "version": "extension_version" -- optional
}
```
If **download** attribute is not set, the script will try to fetch a vsix file from openvsx.org
If **version** is not set, the latest version of an extension will be downloaded.


I set a version for redhat.java extension, because latest version from openvs.org is pre-release version, for more details see https://coreos.slack.com/archives/CRUQDU2BH/p1667939074337899
### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3507 and https://issues.redhat.com/browse/CRW-3477