### PR TITLE
chore: add GH PR check to validate list of vsix files definition

### DIFF
--- a/.github/workflows/vsix-definition-pr-check.yaml
+++ b/.github/workflows/vsix-definition-pr-check.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: VSIX Definition PR Check
+
+on: 
+  pull_request:
+    paths:
+    - 'dependencies/che-plugin-registry/openvsx-sync.json'
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Clone source code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+
+    - name: Validate content
+      run: |
+        cd dependencies/che-plugin-registry/build/scripts/test
+        ./validate_vsix_list.sh

--- a/dependencies/che-plugin-registry/build/scripts/test/validate_vsix_list.sh
+++ b/dependencies/che-plugin-registry/build/scripts/test/validate_vsix_list.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-#
-# Copyright (c) 2018-2022 Red Hat, Inc.
-# This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-#
+# 
+# The script is used by GitHub PR check action "VSIX Definition PR Check", 
+# it validates the IDs of VS Code extensions from openvsx-sync.json file 
 
 trap EXIT
 
@@ -62,7 +61,11 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
     fi
     
     # Publisher and name should be divided by . in extension's id
-    if [[ $vsixFullName != *.* ]]; then
+    # extract from the vsix name the publisher name which is the first part of the vsix name before dot
+    vsixPublisher=${vsixFullName%.*}
+    # extract from the vsix name the extension name which is the second part of the vsix name after dot
+    vsixName=${vsixFullName##*.}
+    if [[ $vsixFullName != *.* ]] || [[ -z "$vsixPublisher" ]] || [[ -z "$vsixName" ]]; then
       echo -e "Publisher and name should be divided by . for $vsixFullName"
       echo -e "${RED}${EMOJI_FAIL}${RESETSTYLE} Test failed!"
       exit 1

--- a/dependencies/che-plugin-registry/build/scripts/test/validate_vsix_list.sh
+++ b/dependencies/che-plugin-registry/build/scripts/test/validate_vsix_list.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Copyright (c) 2018-2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+trap EXIT
+
+RED="\e[31m"
+GREEN="\e[32m"
+RESETSTYLE="\e[0m"
+BOLD="\e[1m"
+DEFAULT_EMOJI_HEADER="🏃" # could be overiden with EMOJI_HEADER="-"
+EMOJI_HEADER=${EMOJI_HEADER:-$DEFAULT_EMOJI_HEADER}
+DEFAULT_EMOJI_PASS="✔" # could be overriden with EMOJI_PASS="[PASS]"
+EMOJI_PASS=${EMOJI_PASS:-$DEFAULT_EMOJI_PASS}
+DEFAULT_EMOJI_FAIL="✘" # could be overriden with EMOJI_FAIL="[FAIL]"
+EMOJI_FAIL=${EMOJI_FAIL:-$DEFAULT_EMOJI_FAIL}
+
+function initTest() {
+    echo -e "${BOLD}\n${EMOJI_HEADER} ${1}${RESETSTYLE}"
+}
+
+echo -e "${BOLD}\n${EMOJI_HEADER}${EMOJI_HEADER}${EMOJI_HEADER} Validate content of openvsx_sync.json: ${BASH_SOURCE[0]}${RESETSTYLE}"
+
+################################################################
+openVsxSyncFileContent=$(cat "../../../openvsx-sync.json")
+numberOfExtensions=$(echo "${openVsxSyncFileContent}" | jq ". | length")
+echo "The number of extensions is $numberOfExtensions"
+IFS=$'\n' 
+
+for i in $(seq 0 "$((numberOfExtensions - 1))"); do
+    vsixFullName=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].id")
+    initTest "Checking $vsixFullName"
+
+    # id should be set 
+    if [[ $vsixFullName == null ]] || [[ -z "$vsixFullName" ]]; then
+      echo -e "ID of the extension with number $i wasn't set"
+      echo -e "${RED}${EMOJI_FAIL}${RESETSTYLE} Test failed!"
+      exit 1
+    fi
+    
+    vsixDownloadLink=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].download")
+    vsixVersion=$(echo "${openVsxSyncFileContent}" | jq -r ".[$i].version")
+
+    # version should not be empty if download link was set
+    if [[ $vsixDownloadLink != null ]] && [[ -z "$vsixVersion" ]]; then
+      echo -e "Version should not be empty for $vsixFullName"
+      echo -e "${RED}${EMOJI_FAIL}${RESETSTYLE} Test failed!"
+      exit 1
+    fi
+    
+    # version should be set if download link was set
+    if [[ $vsixDownloadLink != null ]] && [[ $vsixVersion == null ]]; then
+      echo -e "Version is not defined for $vsixFullName"
+      echo -e "${RED}${EMOJI_FAIL}${RESETSTYLE} Test failed!"
+      exit 1
+    fi
+    
+    # Publisher and name should be divided by . in extension's id
+    if [[ $vsixFullName != *.* ]]; then
+      echo -e "Publisher and name should be divided by . for $vsixFullName"
+      echo -e "${RED}${EMOJI_FAIL}${RESETSTYLE} Test failed!"
+      exit 1
+    fi
+
+done;
+
+echo -e "${GREEN}${EMOJI_PASS}${RESETSTYLE} The content is valid!"


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Add GH PR check to validate the definition of VS Code extensions

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3477