### PR TITLE
chore: add -Xmx2048m to JVM_ARGS for running openvsx server

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -117,7 +117,7 @@ ENV LC_ALL=en_US.UTF-8 \
     # use a cached version of the license list and not go over the internet
     # it's needed for openvsx server when vsix is publishing on AirGap environment
     # https://issues.redhat.com/browse/CRW-3481
-    JVM_ARGS="-DSPDXParser.OnlyUseLocalLicenses=true"
+    JVM_ARGS="-DSPDXParser.OnlyUseLocalLicenses=true -Xmx2048m"
 
 RUN \
     echo "======================" && \


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
add -Xmx2048m to JVM_ARGS to avoid java out of memory error when run openvsx server.

The default value is 1024m

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3295
