### PR TITLE
Adding required registries to OCP image configuration when restricted

### DIFF
--- a/product/installDevSpacesFromLatestIIB.sh
+++ b/product/installDevSpacesFromLatestIIB.sh
@@ -309,7 +309,7 @@ addRequiredRegistries() {
 
   # Check to see if the Cluster Configuration is restricted to a specific list of registries
   if [[ $(echo -n ${imageRegistries} | jq '.spec.registrySources.allowedRegistries | length') -eq 0 ]]; then
-    echo "[INFO] OpenShift environment does not have restricted registries - continuing..."
+    echo "[INFO] OpenShift environment does not have restricted registries - nothing to add."
     return 0
   fi
 
@@ -329,7 +329,7 @@ addRequiredRegistries() {
 
   echo -n "${imageRegistries}" | oc apply -f -
 
-  echo "[INFO] OpenShift Cluster image registries updated."
+  echo "[INFO] OpenShift Cluster image registries updated to include: ${ADDITIONAL_REGISTRIES[*]}"
 }
 
 addRequiredRegistries


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
This PR updates the `installDevSpacesFromLatestIIB` script to enable required registries in the `allowedRegistries` / `allowedRegistriesForImport` cluster configuration when the cluster is already restricted. The script will not add these if no restriction exists.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
