### PR TITLE
chore: add container-contribution attribute into the editor definition

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -110,6 +110,26 @@ editors:
             - exposedPort: 13131
             - exposedPort: 13132
             - exposedPort: 13133
+      - name: theia-ide-contributions
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          args:
+            - sh
+            - '-c'
+            - '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'
+          env:
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins/sidecars/tools
+          memoryLimit: 512Mi
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: remote-endpoint
+              path: /remote-endpoint
+          image: "registry.redhat.io/devspaces/udi-rhel8:3.5"
       - name: plugins
         volume: {}
       - name: theia-local
@@ -339,5 +359,6 @@ editors:
         attributes:
           app.kubernetes.io/component: che-code-runtime
           app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/container-contribution: true
       - name: checode
         volume: {}


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds container-contribution attribute for VS Code and Theia editors.

**_NOTE_: The IDEA editor wasn't changed**

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3612

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
