### PR TITLE
fix: disable ElasticSearch for openvsix registry

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
+++ b/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
@@ -4,6 +4,7 @@ server:
 spring:
   profiles:
     include: ovsx
+  # Disable embedded elasticsearch 
   autoconfigure:
     exclude: 
       - org.jobrunr.spring.autoconfigure.storage.JobRunrElasticSearchStorageAutoConfiguration

--- a/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
+++ b/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
@@ -4,6 +4,12 @@ server:
 spring:
   profiles:
     include: ovsx
+  autoconfigure:
+    exclude: 
+      - org.jobrunr.spring.autoconfigure.storage.JobRunrElasticSearchStorageAutoConfiguration
+  cache:
+    jcache:
+      config: classpath:ehcache.xml
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres
     username: postgres


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Disables ElasticSearch for built-in open-vsix server.
It is required to do after rebasing of https://github.com/che-incubator/che-openvsx/tree/che-openvsx

With this fix all the built-in extensions are not marked as installing anymore

![Screenshot from 2023-01-12 18-01-18](https://user-images.githubusercontent.com/1655894/212118012-2c7695ec-4930-4096-9541-9897618b183d.png)

Docker image to test **quay.io/vgulyy/pluginregistry-rhel8:crw-3544**

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3544
https://issues.redhat.com/browse/CRW-3506

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
