### PR TITLE
chore: increase memoryLimit for che-code-injector component

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -307,7 +307,7 @@ editors:
           volumeMounts:
             - name: checode
               path: /checode
-          memoryLimit: 128Mi
+          memoryLimit: 256Mi
           memoryRequest: 32Mi
           cpuLimit: 500m
           cpuRequest: 30m


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Increase memoryLimit for che-code-injector component to 256Mi

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21719

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
