### PR TITLE
fix: mark idea-rhel8 component as container-contribution

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -255,8 +255,9 @@ editors:
                 discoverable: false
                 urlRewriteSupported: false
         attributes:
-          app.kubernetes.io/component: idea-rhel8-injector
+          app.kubernetes.io/component: idea-rhel8-runtime
           app.kubernetes.io/part-of: idea-rhel8.eclipse.org
+          controller.devfile.io/container-contribution: true
       - name: projector-volume
         volume: { }
       - name: projector-configuration


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
1. Marks `idea-rhel8` component of IDEA editor as container contribution.
2. Replaces `app.kubernetes.io/component: che-rhel8-injector` on `app.kubernetes.io/component: che-rhel8-runtime` to be consistent with `che-code` where everything works without issues

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21878

Depends on https://github.com/eclipse/che/issues/21738

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
