### PR TITLE
chore: generate DWs with VS Code latest

### DIFF
--- a/dependencies/che-devfile-registry/build.sh
+++ b/dependencies/che-devfile-registry/build.sh
@@ -84,7 +84,7 @@ function clear_generated_data() {
       if [[ -f "$CHE_THEIA_DW" ]]; then
         rm "${CHE_THEIA_DW}"
       fi
-      CHE_CODE_DW="${dir}/devworkspace-che-code-insiders.yaml"
+      CHE_CODE_DW="${dir}/devworkspace-che-code-latest.yaml"
       if [[ -f "$CHE_CODE_DW" ]]; then
         rm "${CHE_CODE_DW}"
       fi

--- a/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
+++ b/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
@@ -54,12 +54,12 @@ do
     --output-file:"${dir}"devworkspace-che-theia-latest.yaml \
     --project."${project}"
 
-    # Generate devworkspace-che-code-insiders.yaml
+    # Generate devworkspace-che-code-latest.yaml
     npm_config_yes=true npx @eclipse-che/${che_devworkspace_generator} \
     --devfile-url:"${devfile_url}" \
-    --editor-entry:che-incubator/che-code/insiders \
+    --editor-entry:che-incubator/che-code/latest \
     --plugin-registry-url:https://redhat-developer.github.io/devspaces/che-plugin-registry/"${VERSION}"/"${arch}"/v3 \
-    --output-file:"${dir}"devworkspace-che-code-insiders.yaml \
+    --output-file:"${dir}"devworkspace-che-code-latest.yaml \
     --project."${project}"
 
     # Generate devworkspace-che-idea-latest.yaml

--- a/dependencies/che-devfile-registry/build/scripts/index.sh
+++ b/dependencies/che-devfile-registry/build/scripts/index.sh
@@ -19,7 +19,7 @@ for meta in "${metas[@]}"; do
       cat <<< "$(yq -y --arg metadir "${META_DIR}" '.links.devWorkspaces |= . +
       {"eclipse/che-theia/latest": "/\($metadir)/devworkspace-che-theia-latest.yaml",
       "eclipse/che-idea/latest": "/\($metadir)/devworkspace-che-idea-latest.yaml",
-      "che-incubator/che-code/insiders": "/\($metadir)/devworkspace-che-code-insiders.yaml",}' "${meta}")" > "${meta}"
+      "che-incubator/che-code/latest": "/\($metadir)/devworkspace-che-code-latest.yaml",}' "${meta}")" > "${meta}"
     fi
 done
 yq -s 'map(.)' "${metas[@]}"


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use `editor-entry:che-incubator/che-code/latest` to generate DWs instead of `editor-entry:che-incubator/che-code/insiders`

**_NOTE_**: this PR depends on https://github.com/redhat-developer/devspaces/pull/885 and should be merge after
### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3568
