### PR TITLE
feat: add latest floating tag for DevSpace Samples during release tagging process

### DIFF
--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -197,14 +197,14 @@ pushBranchAndOrTagGH () {
 		git push origin "${CSV_VERSION}" || true
 		# update latest floating tag for samples
 		if [[ $org == "${samplesRepo}" ]]; then
-			# check all 3.*.* tags in the repo, if tag exists with a higher version than the new tag
+			# check all of the 3.*.* tags in the repo, if tag exists with a higher version than the new tag
 			# then latest floating tag should not be updated
 			LATEST_TAG=$(git tag -l -n 3.*.* --sort -version:refname | head -n 1 | grep "3.*.*")
 			if { echo "${CSV_VERSION}"; echo "${LATEST_TAG}"; } | sort --version-sort --check;then
-				echo "[DEBUG] Sample version ${d} is less than latest version";
+				echo "[DEBUG] Sample version ${d} is less than latest ${LATEST_TAG} version, not updating the latest tag";
 			else
 				echo "[DEBUG] Updating latest tag of sample ${d} with ${CSV_VERSION}"
-				git tag -D "latest"
+				git tag -d "latest"
 				git tag "latest"
 				git push origin "latest" -f || true
 			fi

--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -199,14 +199,14 @@ pushBranchAndOrTagGH () {
 		if [[ $org == "${samplesRepo}" ]]; then
 			# check all of the 3.*.* tags in the repo, if tag exists with a higher version than the new tag
 			# then latest floating tag should not be updated
-			LATEST_TAG=$(git tag -l -n 3.*.* --sort -version:refname | head -n 1 | grep "3.*.*")
+			LATEST_TAG=$(git tag -l -n 3.*.* --sort -version:refname | head -n 1 | grep -o "3.[0-9]*.[0-9]*")
 			if { echo "${CSV_VERSION}"; echo "${LATEST_TAG}"; } | sort --version-sort --check;then
 				echo "[DEBUG] Sample version ${d} is less than latest ${LATEST_TAG} version, not updating the latest tag";
 			else
 				echo "[DEBUG] Updating latest tag of sample ${d} with ${CSV_VERSION}"
-				git tag -d "latest"
+				git tag -d "latest" || true
 				git tag "latest"
-				git push origin "latest" -f || true
+				git push origin "latest"
 			fi
 		fi
 	fi

--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -195,6 +195,10 @@ pushBranchAndOrTagGH () {
 	if [[ $CSV_VERSION ]]; then # push a new tag (or no-op if exists)
 		git tag "${CSV_VERSION}" || true
 		git push origin "${CSV_VERSION}" || true
+    # for sample projects, update (force push) the update
+    if [[ $org == "${samplesRepo}" ]]; then
+      git push origin "${CSV_VERSION}:latest" -f || true
+    fi
 	fi
 	popd >/dev/null || exit 1
 }

--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -201,9 +201,9 @@ pushBranchAndOrTagGH () {
 			# then latest floating tag should not be updated
 			LATEST_TAG=$(git tag -l -n 3.*.* --sort -version:refname | head -n 1 | grep "3.*.*")
 			if { echo "${CSV_VERSION}"; echo "${LATEST_TAG}"; } | sort --version-sort --check;then
-				echo "[DEBUG] Sample version  is less than latest version";
+				echo "[DEBUG] Sample version ${d} is less than latest version";
 			else
-				echo "[DEBUG] Updating latest tag of sample $d with ${CSV_VERSION}"
+				echo "[DEBUG] Updating latest tag of sample ${d} with ${CSV_VERSION}"
 				git tag -D "latest"
 				git tag "latest"
 				git push origin "latest" -f || true

--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -206,7 +206,7 @@ pushBranchAndOrTagGH () {
 				echo "[DEBUG] Updating latest tag of sample ${d} with ${CSV_VERSION}"
 				git tag -d "latest" || true
 				git tag "latest"
-				git push origin "latest"
+				git push origin "latest" -f
 			fi
 		fi
 	fi


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
For devspaces samples, a floating tag 'latest' will exist that will point to the latest release version of the sample
When tagging release, samples projects will have the 'latest' tagged updated with the release version (except for the cases, when a "lower" bugfix version like 3.5.1 gets released, when 3.6.0 already exists)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3805

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
