### PR TITLE
fix: update INTERNAL_URL pattern to be replaced

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
@@ -242,7 +242,7 @@ function set_internal_url() {
   if [ -n "$INTERNAL_URL" ]; then
     INTERNAL_URL=${INTERNAL_URL%/}
     echo "Updating internal URL in files to ${INTERNAL_URL}"
-    sed -i "s|{{INTERNAL_URL}}|${INTERNAL_URL}|" "${metas[@]}" "${templates[@]}" "$INDEX_JSON"
+    sed -i "s|{{ INTERNAL_URL }}|${INTERNAL_URL}|" "${metas[@]}" "${templates[@]}" "$INDEX_JSON"
   fi
 }
 

--- a/dependencies/che-devfile-registry/build/dockerfiles/test_entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/test_entrypoint.sh
@@ -164,7 +164,7 @@ spec:
     projects:
       - name: bash
         zip:
-          location: '{{INTERNAL_URL}}/resources/v2/bash.zip'
+          location: '{{ INTERNAL_URL }}/resources/v2/bash.zip'
 END
 )
 


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates entrypoint.sh to correctly replace  INTERNAL_URL with value of CHE_DEVFILE_REGISTRY_INTERNAL_URL.
The problem was caused by [replacing a library that generated devworkspaces](https://github.com/redhat-developer/devspaces/pull/870). 
Now it has the same format as in [upstream](https://github.com/eclipse-che/che-devfile-registry/blob/main/build/dockerfiles/entrypoint.sh#L142) 

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3941
