### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/plugin-registry-build.yaml
+++ b/.github/workflows/plugin-registry-build.yaml
@@ -33,7 +33,7 @@ jobs:
           node-version: '16'
 
       - name: Login to the Red Hat Registry
-        uses: azure/docker-login@v1
+        uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 #v1
         with:
           login-server: registry.redhat.io
           username: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}

--- a/.github/workflows/plugin-registry-pr-check-build-publish-content.yaml
+++ b/.github/workflows/plugin-registry-pr-check-build-publish-content.yaml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: download dist artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415 #v2
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: plugin-registry-content-devspaces
           path: content
       - name: PR number
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415 #v2
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: pull-request-number
@@ -44,7 +44,7 @@ jobs:
           fi
           echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
       - name: PR sha
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415 #v2
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: pull-request-sha

--- a/.github/workflows/plugin-registry-pr-check-build.yaml
+++ b/.github/workflows/plugin-registry-pr-check-build.yaml
@@ -53,14 +53,14 @@ jobs:
           download-unpacked-cache-
 
     - name: Login to Quay.io
-      uses: azure/docker-login@v1
+      uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 #v1
       with:
         login-server: quay.io
         username: ${{ secrets.DS_QUAY_USERNAME }}
         password: ${{ secrets.DS_QUAY_PASSWORD }}
 
     - name: Login to the Red Hat Registry
-      uses: azure/docker-login@v1
+      uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 #v1
       with:
         login-server: registry.redhat.io
         username: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}

--- a/.github/workflows/pr-check-linelint.yaml
+++ b/.github/workflows/pr-check-linelint.yaml
@@ -28,5 +28,5 @@ jobs:
         with:
           fetch-depth: 0
       - name: Linelint
-        uses: fernandrone/linelint@0.0.6
+        uses: fernandrone/linelint@7907a5dca0c28ea7dd05c6d8d8cacded713aca11 #0.0.6
         id: linelint


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
