### PR TITLE
fix: generate devworkspaces with che-code:insiders

### DIFF
--- a/dependencies/che-devfile-registry/build.sh
+++ b/dependencies/che-devfile-registry/build.sh
@@ -84,6 +84,10 @@ function clear_generated_data() {
       if [[ -f "$CHE_THEIA_DW" ]]; then
         rm "${CHE_THEIA_DW}"
       fi
+      CHE_CODE_DW="${dir}/devworkspace-che-code-insiders.yaml"
+      if [[ -f "$CHE_CODE_DW" ]]; then
+        rm "${CHE_CODE_DW}"
+      fi
       CHE_CODE_DW="${dir}/devworkspace-che-code-latest.yaml"
       if [[ -f "$CHE_CODE_DW" ]]; then
         rm "${CHE_CODE_DW}"

--- a/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
+++ b/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
@@ -54,6 +54,14 @@ do
     --output-file:"${dir}"devworkspace-che-theia-latest.yaml \
     --project."${project}"
 
+    # Generate devworkspace-che-code-insiders.yaml
+    npm_config_yes=true npx @eclipse-che/${che_devworkspace_generator} \
+    --devfile-url:"${devfile_url}" \
+    --editor-entry:che-incubator/che-code/insiders \
+    --plugin-registry-url:https://redhat-developer.github.io/devspaces/che-plugin-registry/"${VERSION}"/"${arch}"/v3 \
+    --output-file:"${dir}"devworkspace-che-code-insiders.yaml \
+    --project."${project}"
+
     # Generate devworkspace-che-code-latest.yaml
     npm_config_yes=true npx @eclipse-che/${che_devworkspace_generator} \
     --devfile-url:"${devfile_url}" \

--- a/dependencies/che-devfile-registry/build/scripts/index.sh
+++ b/dependencies/che-devfile-registry/build/scripts/index.sh
@@ -19,6 +19,7 @@ for meta in "${metas[@]}"; do
       cat <<< "$(yq -y --arg metadir "${META_DIR}" '.links.devWorkspaces |= . +
       {"eclipse/che-theia/latest": "/\($metadir)/devworkspace-che-theia-latest.yaml",
       "eclipse/che-idea/latest": "/\($metadir)/devworkspace-che-idea-latest.yaml",
+      "che-incubator/che-code/insiders": "/\($metadir)/devworkspace-che-code-insiders.yaml",
       "che-incubator/che-code/latest": "/\($metadir)/devworkspace-che-code-latest.yaml",}' "${meta}")" > "${meta}"
     fi
 done

--- a/dependencies/che-devfile-registry/build/scripts/index.sh
+++ b/dependencies/che-devfile-registry/build/scripts/index.sh
@@ -20,7 +20,7 @@ for meta in "${metas[@]}"; do
       {"eclipse/che-theia/latest": "/\($metadir)/devworkspace-che-theia-latest.yaml",
       "eclipse/che-idea/latest": "/\($metadir)/devworkspace-che-idea-latest.yaml",
       "che-incubator/che-code/insiders": "/\($metadir)/devworkspace-che-code-insiders.yaml",
-      "che-incubator/che-code/latest": "/\($metadir)/devworkspace-che-code-latest.yaml",}' "${meta}")" > "${meta}"
+      "che-incubator/che-code/latest": "/\($metadir)/devworkspace-che-code-latest.yaml"}' "${meta}")" > "${meta}"
     fi
 done
 yq -s 'map(.)' "${metas[@]}"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Generates DevWorkspaces with che-code:insiders editor to support che-code:insiders as a default editor that was set in the older DS versions.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4074

