### PR TITLE
fix: Do not duplicate che-theia commands

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -13,12 +13,12 @@ editors:
         repository: https://github.com/eclipse-che/che-theia
         firstPublicationDate: '2019-03-07'
     commands:
-      - id: init-remote-runtime-injector
+      - id: init-container-command
         apply:
           component: remote-runtime-injector
     events:
       preStart:
-        - init-remote-runtime-injector
+        - init-container-command
     components:
       - name: theia-ide
         container:


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Rename `preStart` che-theia command.
We need this change because of upstream changes: https://github.com/eclipse-che/che-plugin-registry/pull/1613

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/22071

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
