### PR TITLE
feat: Use post-start event to start VS Code

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -297,9 +297,15 @@ editors:
       - id: init-container-command
         apply:
           component: che-code-injector
+      - id: init-che-code-command
+        exec:
+          component: che-code-runtime-description
+          commandLine: 'nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt 2>&1 &'
     events:
       preStart:
         - init-container-command
+      postStart:
+        - init-che-code-command
     components:
       - name: che-code-injector
         container:
@@ -319,8 +325,6 @@ editors:
           memoryRequest: 256Mi
           cpuLimit: 500m
           cpuRequest: 30m
-          command:
-            - /checode/entrypoint-volume.sh
           volumeMounts:
             - name: checode
               path: /checode
@@ -379,9 +383,15 @@ editors:
       - id: init-container-command
         apply:
           component: che-code-injector
+      - id: init-che-code-command
+        exec:
+          component: che-code-runtime-description
+          commandLine: 'nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt 2>&1 &'
     events:
       preStart:
         - init-container-command
+      postStart:
+        - init-che-code-command
     components:
       - name: che-code-injector
         container:
@@ -401,8 +411,6 @@ editors:
           memoryRequest: 256Mi
           cpuLimit: 500m
           cpuRequest: 30m
-          command:
-            - /checode/entrypoint-volume.sh
           volumeMounts:
             - name: checode
               path: /checode


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use post-start event instead of command to start VS Code
Upstream changes: https://github.com/eclipse-che/che-plugin-registry/pull/1566

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21879

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
