### PR TITLE
feat: Use post-start event to start JetBrains IDE

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -196,15 +196,19 @@ editors:
       - id: init-container-command
         apply:
           component: idea-rhel8-injector
+      - id: init-che-idea-command
+        exec:
+          component: idea-rhel8
+          commandLine: 'nohup /projector/entrypoint-volume.sh > /projector/entrypoint-logs.txt 2>&1 &'
     events:
       preStart:
         - init-container-command
+      postStart:
+        - init-che-idea-command
     components:
       - name: idea-rhel8
         container:
           image: 'registry.redhat.io/devspaces/udi-rhel8:3.6'
-          command:
-            - /projector/entrypoint-volume.sh
           env:
             - name: PROJECTOR_ASSEMBLY_DIR
               value: /projector


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use post-start event instead of command to start IntelliJ IDEA.
Upstream changes: https://github.com/eclipse-che/che-plugin-registry/pull/1623

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22034

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
