### PR TITLE
fix: chore: CRW-3830 Release Note Text custom field ID changed; also CRW-4151 add Affects = Release Notes

### DIFF
--- a/product/ghira/ghira
+++ b/product/ghira/ghira
@@ -172,7 +172,7 @@ class IssueToJIRA:
 
   # for debugging, dump json for a complete issue to help figure out field names
   # can also use JQL to see mapping of field name to field ID
-  # i=j.issue("CRW-3643")
+  # i=j.issue("CRW-4150")
   # print(json.dumps(i.raw,indent=2))
 
   # map github issue to jira issue
@@ -187,8 +187,12 @@ class IssueToJIRA:
     'project': 'CRW',
     'issuetype': {'name': 'Task'},
     'components': [{"name": "docs"}],
+    # Affects = Release Notes
+    'customfield_12310031': [{"self": "https://issues.redhat.com/rest/api/2/customFieldOption/10090", "value": "Release Notes", "id": "10090", "disabled": False}],
+    # "Release Note Text_Old" (will set this to a better value later)
+    #'customfield_12310211': 'To be written by team lead or assignee',
     # "Release Note Text" (will set this to a better value later)
-    'customfield_12310211': 'To be written by team lead or assignee',
+    'customfield_12317313': 'To be written by team lead or assignee',
     # "Release Note Status"
     'customfield_12310213': {'value': 'Proposed'}
     # TODO can we guess this from the upstream issue labels / body / comments?
@@ -420,7 +424,7 @@ for i in pending_issues:
       customfields[k] = v
   # set the release notes text field to the value of the upstream issue + release notes text content in the uptream issue description, if available
   # scrape out just the content after RELEASE NOTES TEXT line
-  customfields["customfield_12310211"] = "= " + new_jira["summary"] + new_jira["description"].partition("Release Notes Text")[2]
+  customfields["customfield_12317313"] = "= " + new_jira["summary"] + new_jira["description"].partition("Release Notes Text")[2]
   for k in customfields.keys():
     del new_jira[k]
 


### PR DESCRIPTION
### What does this PR do?

fix: chore: Release Note Text custom field ID has changed from customfield_12310211 to customfield_12317313 (was causing 400 error in jenkins and local run);
also CRW-4151 - add Affects = Release Notes to these generated issues

Change-Id: I1d282a91d80c740c232c190647ce69e3dd662fd5
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.