### PR TITLE
chore: CRW-4192 - hardcode to a specific tag...

### DIFF
--- a/product/buildCatalog.sh
+++ b/product/buildCatalog.sh
@@ -99,7 +99,8 @@ $PODMAN rmi --ignore --force $targetIndexImage >/dev/null 2>&1 || true
 
 # new way for OCP 4.12+
 # CRW-4063 - don't use version newer than 4.11 as it seems to produce catalog sources we can't use in OCP 4.12+
-OSE_VER="v4.11" 
+# CRW-4192 - hardcode to a specific tag which uses an older golang 1.18.7 (before fixing https://pkg.go.dev/vuln/GO-2022-1143 -> 1.18.9)
+OSE_VER="v4.11.0-202302271715.p0.g7fdc3c5.assembly.stream" 
 cat <<EOF > olm-catalog.Dockerfile
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe


### PR DESCRIPTION
### What does this PR do?

chore: CRW-4192 - hardcode to a specific tag which uses an older golang 1.18.7 (before fixing https://pkg.go.dev/vuln/GO-2022-1143 -> 1.18.9) (#937)

temporary hack; should really move up to v4.12 latest if possible

Change-Id: Ifc85a7d66f157363251a9cc476245a681bcf722b

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.