### PR TITLE
fix: chore: CRW-4354 CRW-4324 DO NOT USE...

### DIFF
--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -541,9 +541,7 @@
       },
       "3.6": {
         "CSV_VERSION": "3.6.0",
-        "CSV_VERSION_PREV": "3.5.0-0.1682130576.p"
         "CSV_VERSION_PREV": "3.5.0"
-        "CSV_VERSION_PREV": "3.5.0-0.1682130576.p"
       },
       "3.x": {
         "CSV_VERSION": "3.6.0",

--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -541,7 +541,9 @@
       },
       "3.6": {
         "CSV_VERSION": "3.6.0",
+        "CSV_VERSION_PREV": "3.5.0-0.1682130576.p"
         "CSV_VERSION_PREV": "3.5.0"
+        "CSV_VERSION_PREV": "3.5.0-0.1682130576.p"
       },
       "3.x": {
         "CSV_VERSION": "3.6.0",


### PR DESCRIPTION
### What does this PR do?

fix: chore: CRW-4354 CRW-4324 DO NOT USE Freshmaker version suffix for CSV_VERSION_PREV in job-config.json, for 'replaces:' logic in CSVs.
Assume FM lifecycle will do its own thing with olm.substitutesFor (grafting their fixes onto our branch) rather than injecting itself into our branch directly

Change-Id: I50d68df842fda69cdfae4d3d223eed8798b62087
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.