### PR TITLE
feat: remove >= from the engine's version before comparing

### DIFF
--- a/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
@@ -60,6 +60,8 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
                 vscodeEngineVersion=$(echo "${vsixMetadata}" | jq -r '.engines.vscode')
                 # remove ^ from the engine version
                 vscodeEngineVersion="${vscodeEngineVersion//^/}"
+                # remove >= from the engine version
+                vscodeEngineVersion="${vscodeEngineVersion//>=/}"
                 # replace x by 0 in the engine version
                 vscodeEngineVersion="${vscodeEngineVersion//x/0}"
                 # check if the extension's engine version is compatible with the code version


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Some vscode extensions provide metadata with vscode engine version that contains `>=` (for example https://open-vsx.org/api/stylelint/vscode-stylelint/latest)
This PR removes `>=` before comparing wit Che Code version

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4165