### PR TITLE
chore: add Tech Preview info for IDEA editor in the User Dashboard

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -3,7 +3,7 @@ editors:
   - schemaVersion: 2.1.0
     metadata:
       name: che-incubator/che-idea/latest
-      displayName: IntelliJ IDEA Community
+      displayName: IntelliJ IDEA Community (Technology Preview)
       description: Red Hat OpenShift Dev Spaces with JetBrains IntelliJ IDEA Community IDE
       icon: https://resources.jetbrains.com/storage/products/intellij-idea/img/meta/intellij-idea_logo_300x300.png
       attributes:


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Changes a display name of Che Idea editor to mark it as a tech preview.

**IntelliJ IDEA Community (Technology Preview)**

These changes will be shown on the User Dashboard when open editor's drop-down list:

![screenshot-nimbusweb me-2023 05 18-11_17_30](https://github.com/redhat-developer/devspaces/assets/1271546/bb522add-be17-46f5-bbdf-5c25fe9d8f12)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4139

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
