### PR TITLE
Update tagRelease.sh to include devspaces-vscode-extensions

### DIFF
--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -258,6 +258,7 @@ for repo in \
 devspaces \
 devspaces-chectl \
 devspaces-images \
+devspaces-vscode-extensions \
 ; do
 	pushBranchAndOrTagGH $repo "redhat-developer"
 done


### PR DESCRIPTION
### What does this PR do?
Adds devspaces-vscode-extensions since it has been redesigned to follow the devspaces-3.x-rhel-8 branching convention.

### What issues does this PR fix or reference?
The jenkins jobs for non 3.x branches breaks when I forget to manually create a new branch.