### PR TITLE
chore: add devfile.yaml to work with plugin registry

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,59 @@
+schemaVersion: 2.2.0
+metadata:
+  name: ds-plugin-registry-dev
+components:
+  - name: builder
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      memoryRequest: 256Mi
+      memoryLimit: 8Gi
+      cpuRequest: 100m
+      cpuLimit: 2000m
+      env:
+        - name: CONCURRENTLY_OPTS
+          value: -m 1
+      endpoints:
+        - name: openvsx
+          exposure: internal
+          targetPort: 5432
+commands:
+  - id: podman-login
+    exec:
+      label: "1. Login to registry.redhat.io"
+      commandLine: podman login registry.redhat.io
+      component: builder
+  - id: build
+    exec:
+      label: "2. Build and Publish a Custom Plugin Registry"
+      component: builder
+      workingDir: ${PROJECTS_ROOT}/devspaces/dependencies/che-plugin-registry
+      commandLine: |
+          set -o xtrace;
+          rm -rf output;
+          mkdir output;
+          BUILDER=podman SKIP_TEST=true SKIP_FORMAT=true SKIP_LINT=true NODE_BUILD_OPTIONS="-max-old-space-size=1024" ./build.sh &&
+          export IMAGE=image-registry.openshift-image-registry.svc:5000/$(kubectl get sa default -o json | jq -r '.metadata.namespace')/che-plugin-registry &&
+          podman tag quay.io/devspaces/pluginregistry-rhel8:next ${IMAGE} &&
+          podman login --tls-verify=false -u $(oc whoami | tr -d :) -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000 &&
+          podman push --tls-verify=false "${IMAGE}"
+  - id: configure-custom-plugin-registry
+    exec:
+      label: "3. Configure Che to use the Custom Plugin Registry"
+      component: builder
+      workingDir: ${PROJECTS_ROOT}/devspaces/dependencies/che-plugin-registry
+      commandLine: |
+          export IMAGE=image-registry.openshift-image-registry.svc:5000/$(kubectl get sa default -o json | jq -r '.metadata.namespace')/che-plugin-registry &&
+          export CHECLUSTER_NAMESPACE="$(kubectl get checluster --all-namespaces -o json | jq -r '.items[0].metadata.namespace')" &&
+          kubectl create secret -n "${CHECLUSTER_NAMESPACE}" docker-registry regcred --docker-server=image-registry.openshift-image-registry.svc:5000 --docker-username=$(oc whoami | tr -d :) --docker-password=$(oc whoami -t) &&
+          kubectl patch serviceaccount default -n "${CHECLUSTER_NAMESPACE}" -p '{"imagePullSecrets": [{"name": "regcred"}]}' &&
+          ./patch-cluster.sh "${IMAGE}"
+  - id: enable-embedded-openvsx
+    exec:
+      label: "4. Configure Che to use the embedded Eclipse Open VSX server"
+      component: builder
+      workingDir: ${PROJECTS_ROOT}/devspaces/dependencies/che-plugin-registry
+      commandLine: |
+          export CHECLUSTER_NAME="$(kubectl get checluster --all-namespaces -o json | jq -r '.items[0].metadata.name')" &&
+          export CHECLUSTER_NAMESPACE="$(kubectl get checluster --all-namespaces -o json | jq -r '.items[0].metadata.namespace')" &&
+          export PATCH='{"spec":{"components":{"pluginRegistry":{"openVSXURL":""}}}}' &&
+          kubectl patch checluster "${CHECLUSTER_NAME}" --type=merge --patch "${PATCH}" -n "${CHECLUSTER_NAMESPACE}"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+      "arcanis.vscode-zipfs",
+      "donjayamanne.githistory",
+      "eamodio.gitlens",
+      "GitHub.vscode-pull-request-github",
+      "redhat.vscode-yaml",
+      "timonwong.shellcheck"
+    ]
+  }

--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -47,7 +47,7 @@ WORKDIR /
 
 # Copy OpenVSX server files
 COPY --chown=0:0 /openvsx-server.tar.gz .
-RUN tar -xf openvsx-server.tar.gz && rm openvsx-server.tar.gz
+RUN tar --no-same-owner -xf openvsx-server.tar.gz && rm openvsx-server.tar.gz
 # Copy our configuration file for OpenVSX server
 COPY /build/dockerfiles/application.yaml /openvsx-server/config/
 RUN chmod -R g+rwx /openvsx-server
@@ -76,7 +76,7 @@ COPY README.md .htaccess /var/www/html/
 COPY /build/scripts/*.sh resources.tgz che-*.yaml /build/
 
 RUN chmod 755 /usr/local/bin/*.sh && \
-    tar -xvf /build/resources.tgz -C /build/ && \
+    tar --no-same-owner -xvf /build/resources.tgz -C /build/ && \
     rm -rf /build/output/v3/che-editors.yaml && \
     /build/list_referenced_images.sh /build/output/v3 --use-generated-content > /build/output/v3/external_images.txt && cat /build/output/v3/external_images.txt && \
     chmod -R g+rwX /build && \

--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -42,9 +42,6 @@ COPY ./build/dockerfiles/content_set*.repo /etc/yum.repos.d/
 COPY ./build/dockerfiles/rhel.install.sh /tmp
 RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
 
-# Use the final root filesystem as default directory
-WORKDIR /
-
 # Copy OpenVSX server files
 COPY --chown=0:0 /openvsx-server.tar.gz .
 RUN tar --no-same-owner -xf openvsx-server.tar.gz && rm openvsx-server.tar.gz

--- a/dependencies/che-plugin-registry/patch-cluster.sh
+++ b/dependencies/che-plugin-registry/patch-cluster.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Arguments
+#    $1 - the new plugin registry image
+#
+
+set -e -u
+
+IMAGE=$1
+CHECLUSTER_NAME="$(kubectl get checluster --all-namespaces -o json | jq -r '.items[0].metadata.name')"
+CHECLUSTER_NAMESPACE="$(kubectl get checluster --all-namespaces -o json | jq -r '.items[0].metadata.namespace')"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf -- "$TMPDIR"' EXIT
+cat << EOF > "${TMPDIR}"/patch-file.yaml
+spec:
+  components:
+    pluginRegistry:
+      deployment:
+        containers:
+          - name: plugin-registry
+            image: ${IMAGE}
+EOF
+
+echo "Patching CheCluster ${CHECLUSTER_NAME} in namespace ${CHECLUSTER_NAMESPACE} to use ${IMAGE} as plugin registry image."
+echo
+echo "Original CheCluster .spec.components.pluginRegistry:"
+kubectl get  -n "${CHECLUSTER_NAMESPACE}" checluster "${CHECLUSTER_NAME}" -o json | jq '.spec.components.pluginRegistry' 
+echo
+echo "Patch file:"
+cat "${TMPDIR}"/patch-file.yaml
+echo
+kubectl patch -n "${CHECLUSTER_NAMESPACE}" checluster "${CHECLUSTER_NAME}" --type merge --patch "$(cat "${TMPDIR}"/patch-file.yaml)"
+echo
+echo "Patched CheCluster .spec.components.pluginRegistry:"
+kubectl get -n "${CHECLUSTER_NAMESPACE}" checluster "${CHECLUSTER_NAME}" -o json | jq '.spec.components.pluginRegistry'


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Introduces devfile.yaml with commands that allow to verify changes made in the plugin registry.

It is important to have an access to modify CheCluster definition on OS cluster

Only one extension in the list of the embedded plugin registry:
![screenshot-nimbusweb me-2023 06 09-16_30_25](https://github.com/redhat-developer/devspaces/assets/1271546/df26fdd9-93ae-4240-93ff-405608929da9)

Rresult of the changes:
![screenshot-nimbusweb me-2023 06 09-16_32_31](https://github.com/redhat-developer/devspaces/assets/1271546/ae6fb6f2-f5e2-4e9d-8a07-9feabf111e08)

Related issue: https://github.com/eclipse/che/issues/22243

