### PR TITLE
Avoid overwriting `JAVA_HOME` by IDEA

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -41,7 +41,7 @@ editors:
             - name: projector-configuration
               path: /home/user/.jetbrains
             - name: projector-java-configuration
-              path: /home/user/.java
+              path: /home/user/.projector-java
           memoryLimit: 6144Mi
           memoryRequest: 2048Mi
           cpuLimit: 2000m


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
In the UDI image, `/home/user/.java` is a `JAVA_HOME`.
IDEA editor is overwriting that directory by its config.
This patch changes the IDEA config path.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4525
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
