### PR TITLE
feat(extensions): add ms-python.black-formatter extension

### DIFF
--- a/dependencies/che-plugin-registry/openvsx-sync.json
+++ b/dependencies/che-plugin-registry/openvsx-sync.json
@@ -27,6 +27,9 @@
         "id": "ms-python.python"
     },
     {
+        "id": "ms-python.black-formatter"
+    },
+    {
         "id": "ms-toolsai.jupyter"
     },
     {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Ansible sample requires [ms-python.black-formatter extension](https://github.com/devspaces-samples/ansible-devspaces-demo/blob/devspaces-3.7-rhel-8/.vscode/extensions.json#L6) but the embedded plugin registry doesn't provide it. 
This PR adds ms-python.black-formatter extension into the embedded plugin registry

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4359

