### PR TITLE
feat(extensions): provide appropriate version of che-code to download valid extensions

### DIFF
--- a/dependencies/che-plugin-registry/build.sh
+++ b/dependencies/che-plugin-registry/build.sh
@@ -143,7 +143,15 @@ prepareOpenvsxPackagingAsset() {
         rm "$OPENVSX_ASSET_DEST"
     fi
 
+    SCRIPT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    if [[ $SCRIPT_BRANCH != "devspaces-3."*"-rhel-8" ]]; then
+        SCRIPT_BRANCH="devspaces-3-rhel-8"
+    fi
+
+    # save current branch name to the temporary file
+    echo "$SCRIPT_BRANCH" > current_branch
     ${BUILDER} ${BUILD_COMMAND} --progress=plain --no-cache -f build/dockerfiles/openvsx-builder.Dockerfile -t "$OPENVSX_BUILDER_IMAGE" .
+    rm current_branch 
     # shellcheck disable=SC2181
     if [[ $? -eq 0 ]]; then
         echo "Container '$OPENVSX_BUILDER_IMAGE' successfully built"

--- a/dependencies/che-plugin-registry/build/dockerfiles/openvsx-builder.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/openvsx-builder.Dockerfile
@@ -25,9 +25,13 @@ RUN mkdir /openvsx-server && \
 
 RUN cd /openvsx-server && jar -xf openvsx-server.jar && rm openvsx-server.jar
 
-# Pull vsix files from openvsx
+COPY /current_branch /current_branch
 COPY /openvsx-sync.json /openvsx-server/
 COPY /build/scripts/download_vsix.sh /tmp
-RUN /tmp/download_vsix.sh && mv /tmp/vsix /openvsx-server
+RUN \
+    branch=$(cat /current_branch) && \
+    # Pull vsix files from openvsx
+    /tmp/download_vsix.sh -b $branch $ && mv /tmp/vsix /openvsx-server && \
+    rm /current_branch
 
 RUN tar -czvf openvsx-server.tar.gz openvsx-server \

--- a/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
@@ -21,7 +21,7 @@ All arguments are optional.
 # commandline args
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    '-b'|'--branch') scriptsBranch="$2"; shift 1;;
+    '-b'|'--branch') scriptBranch="$2"; shift 1;;
     '-j'|'--json') openvsxJson="$2"; shift 1;;
     '--no-download') downloadVsix=0;;
     '-h'|'--help') usage;;
@@ -29,14 +29,8 @@ while [[ "$#" -gt 0 ]]; do
   shift 1
 done
 
-if [[ ! "${scriptsBranch}" ]]; then 
-    scriptsBranch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-    if [[ $scriptsBranch != "devspaces-3."*"-rhel-8" ]]; then
-        scriptsBranch="devspaces-3-rhel-8"
-    fi
-fi
-
-codeVersion=$(curl -sSlko- https://raw.githubusercontent.com/redhat-developer/devspaces-images/"${scriptsBranch}"/devspaces-code/code/package.json | jq -r '.version')
+echo "Scripts branch=${scriptBranch}"
+codeVersion=$(curl -sSlko- https://raw.githubusercontent.com/redhat-developer/devspaces-images/"${scriptBranch}"/devspaces-code/code/package.json | jq -r '.version')
 echo "Che Code version=${codeVersion}"
 
 # pull vsix from OpenVSX
@@ -131,6 +125,12 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
         vsixUniversalDownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."universal"')
         if [[ $vsixUniversalDownloadLink != null ]]; then
             vsixDownloadLink=$vsixUniversalDownloadLink
+        else
+            # get linux download link
+            vsixLinuxDownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."linux-x64"')
+            if [[ $vsixLinuxDownloadLink != null ]]; then
+                vsixDownloadLink=$vsixLinuxDownloadLink
+            fi
         fi
     fi
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Gets che-code version that is used in the carrent version of DS to download vscode extension that are supported by the specific editor version.

The output from the build process:
```
....
Scripts branch=devspaces-3-rhel-8
Che Code version=1.80.0
Downloading https://open-vsx.org/api/ms-python/python/2023.10.1/file/ms-python.python-2023.10.1.vsix into ms-python folder...
...
```

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4553
https://issues.redhat.com/browse/CRW-4359