### PR TITLE
fix: cleanup vsix extensions after publishing into the embedded plugin registry

### DIFF
--- a/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
@@ -41,7 +41,13 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
 
     # publish the file
     ovsx publish "${vsixFilename}"
+
+    # remove the downloaded file
+    rm "${vsixFilename}"
 done;
 
 # disable the personal access token
 psql -c "UPDATE personal_access_token SET active = false;"
+
+# cleanup temporary files 
+rm -rf /tmp/extension_*.vsix


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Clean some temporary files to avoid them to be stored in the image
![screenshot-console-openshift-console apps ocp413-aws crw-qe com-2023 07 07-14_25_00](https://github.com/redhat-developer/devspaces/assets/1271546/a3bc474c-8f63-47e4-9d41-e3a8cd641678)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4347

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
N/A