### PR TITLE
fix: set correct path to the python3.11

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
@@ -37,9 +37,9 @@ ${DNF} -y install python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${
 # shellcheck disable=SC2010
 PYTHON_BIN=$(ls -1 /usr/bin | grep -E "^python3.[0-9]$" | sort -V | tail -1 || true) # 3.6, 3.7, 3.8, etc.
 if [[ ! ${PYTHON_BIN} ]]; then
-    PYTHON_BIN=$(/usr/bin/python3 -V | sed -r -e "s#Python ##" -e "s#([0-9])\.([0-9]+)\.([0-9]+)#\1.\2#")
+    PYTHON_BIN=python$(/usr/bin/python3 -V | sed -r -e "s#Python ##" -e "s#([0-9])\.([0-9]+)\.([0-9]+)#\1.\2#")
     if [[ ! ${PYTHON_BIN} ]]; then
-        PYTHON_BIN=$(/usr/bin/python -V | sed -r -e "s#Python ##" -e "s#([0-9])\.([0-9]+)\.([0-9]+)#\1.\2#")
+        PYTHON_BIN=python$(/usr/bin/python -V | sed -r -e "s#Python ##" -e "s#([0-9])\.([0-9]+)\.([0-9]+)#\1.\2#")
     fi
 fi
 if [[ ! -L /usr/bin/python ]]; then


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Fix the path python3.11
