### PR TITLE
chore: upgrade plugin reg to use latest openvsx-server

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -11,8 +11,8 @@
 #   IBM Corporation - implementation
 #
 
-# https://registry.access.redhat.com/rhel8/postgresql-13
-FROM registry.redhat.io/rhel8/postgresql-13:1-130
+# https://registry.access.redhat.com/rhel8/postgresql-15
+FROM registry.redhat.io/rhel8/postgresql-15:1-15
 USER 0
 WORKDIR /
 

--- a/dependencies/che-plugin-registry/build/dockerfiles/openvsx-builder.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/openvsx-builder.Dockerfile
@@ -9,7 +9,7 @@
 # https://registry.access.redhat.com/ubi8/ubi
 FROM registry.access.redhat.com/ubi8/ubi:8.8-1009 as builder
 
-RUN yum install java-11-openjdk-devel git jq unzip curl -y --nodocs && \
+RUN yum install java-17-openjdk-devel git jq unzip curl -y --nodocs && \
     yum update -q -y 
 
 RUN cd /tmp && \

--- a/dependencies/che-plugin-registry/build/dockerfiles/ovsx-installer.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/ovsx-installer.Dockerfile
@@ -12,6 +12,6 @@ USER 1001
 # TODO: do we need to use a cache folder here? 
 ENV npm_config_cache=/tmp/opt/cache
 RUN mkdir -p /tmp/opt/cache && \
-    npm install --location=global ovsx@0.5.0 --prefix /tmp/opt/ovsx --cache /tmp/opt/cache && chmod -R g+rwX /tmp/opt/ovsx && \
+    npm install --location=global ovsx@0.8.2 --prefix /tmp/opt/ovsx --cache /tmp/opt/cache && chmod -R g+rwX /tmp/opt/ovsx && \
     tar -czf ovsx.tar.gz /tmp/opt/ovsx && \
     chmod g+rwX /opt/app-root/src/ovsx.tar.gz

--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
@@ -45,7 +45,7 @@ if [[ ! -L /usr/bin/python ]]; then
 fi
 
 ${DNF} -y install \
-    java-11-openjdk httpd coreutils-single glibc-minimal-langpack glibc-langpack-en langpacks-en glibc-locale-source nc \
+    java-17-openjdk httpd coreutils-single glibc-minimal-langpack glibc-langpack-en langpacks-en glibc-locale-source nc \
     net-tools procps vi curl wget tar gzip jq findutils bash git skopeo \
     --releasever 8 --nodocs
 

--- a/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
@@ -48,6 +48,3 @@ done;
 
 # disable the personal access token
 psql -c "UPDATE personal_access_token SET active = false;"
-
-# cleanup temporary files 
-rm -rf /tmp/extension_*.vsix

--- a/dependencies/che-plugin-registry/openvsx-sync.json
+++ b/dependencies/che-plugin-registry/openvsx-sync.json
@@ -3,6 +3,12 @@
         "id": "donjayamanne.githistory"
     },
     {
+        "id": "redhat.vscode-xml"
+    },
+    {
+        "id": "redhat.vscode-yaml"
+    },
+    {
         "id": "vscode.github-authentication"
     },
     {
@@ -48,9 +54,6 @@
         "id": "golang.go"
     },
     {
-        "id": "redhat.vscode-yaml"
-    },
-    {
         "id": "ms-kubernetes-tools.vscode-kubernetes-tools"
     },
     {
@@ -75,9 +78,6 @@
         "id": "redhat.fabric8-analytics"
     },
     {
-        "id": "redhat.project-initializer"
-    },
-    {
         "id": "redhat.vscode-redhat-account"
     },
     {
@@ -85,9 +85,6 @@
     },
     {
         "id": "xdebug.php-debug"
-    },
-    {
-        "id": "redhat.vscode-xml"
     },
     {
         "id": "muhammad-sammy.csharp"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates plugin registry to use the latest version of openvsx-server provided in https://github.com/che-incubator/che-openvsx/pull/5.
Next tools are going to be updated:
- java to 17
- postgresql to 15
- ovsx to 0.8.2

Remove deprecated redhat.project-initializer extension

![screenshot-nimbusweb me-2023 07 18-12_44_45](https://github.com/redhat-developer/devspaces/assets/1271546/104b4710-a101-4e41-96f1-ed328041ff5a)

![screenshot-devspaces apps rosa qv3vh-dohrj-e6r 1697 p3 openshiftapps com-2023 07 18-12_41_03](https://github.com/redhat-developer/devspaces/assets/1271546/3ba28b22-dd61-4a15-86b2-c757963455f0)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4589

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
N/A