### PR TITLE
Fix: check against tryAgain the second time since checking against tr…

### DIFF
--- a/product/uploadAssetsToGHRelease.sh
+++ b/product/uploadAssetsToGHRelease.sh
@@ -157,7 +157,7 @@ if [[ $PUBLISH_ASSETS -eq 1 ]]; then
       echo "[INFO] $tryAgain"
     fi
     # if release STILL doesn't exist (or upload failed again), try again
-    if [[ $try == *"nable to find release with tag name"* ]] || [[ $try == *"unexpected end of JSON input"* ]]; then
+    if [[ $tryAgain == *"nable to find release with tag name"* ]] || [[ $tryAgain == *"unexpected end of JSON input"* ]]; then
       # if release STILL doesn't exist, create it again (?)
       if [[ $tryAgain == *"nable to find release with tag name"* ]]; then
         echo "[WARNING] GH release 'Assets for the ${CSV_VERSION} ${ASSET_NAME} release' does not exist: create it (2)"


### PR DESCRIPTION
…y results in attempting to check in the same asset twice even if it succeeds.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
