### PR TITLE
chore: update httpd custom logging to filter health checker responses

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
@@ -104,7 +104,8 @@ RUN sed -i /etc/httpd/conf.d/ssl.conf \
 RUN sed -i /etc/httpd/conf/httpd.conf \
     -e "s,Listen 80,Listen 8080," \
     -e "s,logs/error_log,/dev/stderr," \
-    -e "s,logs/access_log,/dev/stdout," \
+    -e "/<IfModule log_config_module>/a SetEnvIf User-Agent \"^kube-probe/\" dontlog" \
+    -e 's,CustomLog "logs/access_log" combined,CustomLog /dev/stdout combined env=!dontlog,' \
     -e "s,AllowOverride None,AllowOverride All," && \
     chmod a+rwX /etc/httpd/conf /run/httpd /etc/httpd/logs/
 STOPSIGNAL SIGWINCH

--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -99,7 +99,8 @@ RUN \
 RUN sed -i /etc/httpd/conf/httpd.conf \
     -e "s,Listen 80,Listen 8080," \
     -e "s,logs/error_log,/dev/stderr," \
-    -e "s,logs/access_log,/dev/stdout," \
+    -e "/<IfModule log_config_module>/a SetEnvIf User-Agent \"^kube-probe/\" dontlog" \
+    -e 's,CustomLog "logs/access_log" combined,CustomLog /dev/stdout combined env=!dontlog,' \
     -e "s,AllowOverride None,AllowOverride All," && \
     chmod a+rwX /etc/httpd/conf /etc/httpd/conf.d /run/httpd /etc/httpd/logs/
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Filtering logs on httpd servers for plugin and devfile registries to skip logs that are responses of OS health checkers

**Devfile registry:**
  
![Screenshot from 2023-07-25 13-27-27](https://github.com/redhat-developer/devspaces/assets/1271546/73c82a31-c9a6-4006-8f6e-06f6dba776fa)

**Plugin registry:**
![Screenshot from 2023-07-25 13-03-18](https://github.com/redhat-developer/devspaces/assets/1271546/fa54cdba-3592-40a5-a0bc-cd4f0c1b6c75)

#### How to test?
- Deploy DS
- Update devspaces CR to use custom images for devfile and plugin registries:
```
    devfileRegistry:
      deployment:
        containers:
          - image: quay.io/vsvydenk/devfileregistry-rhel8:1
......
    pluginRegistry:
      deployment:
        containers:
          - image: quay.io/vsvydenk/pluginregistry-rhel8:1
```
- Wait when plugin and devfile registries pods will be restarted
- Check logs of the plugin and devfile registries pods from the OS console
- From the logs you shouldn't see messages like
```
"GET /devfiles/ HTTP/1.1" 200 8444 "-" "kube-probe/1.25"

"GET /v3/plugins/ HTTP/1.1" 200 1231 "http://10.128.151.66:8080/plugins/" "kube-probe/1.26"
``` 
![screenshot-console-openshift-console apps rosa dhtd8-vsyd6-zod 7tjj p3 openshiftapps com-2023 07 26-15_20_19](https://github.com/redhat-developer/devspaces/assets/1271546/ebfdec40-91a5-4b0e-be7a-9cab3b39a24c)

![screenshot-console-openshift-console apps rosa dhtd8-vsyd6-zod 7tjj p3 openshiftapps com-2023 07 26-15_31_04](https://github.com/redhat-developer/devspaces/assets/1271546/9379b62b-c358-45e5-9e84-488df3830b2a)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4610

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
N/A