### PR TITLE
chore: update httpd custom logging to filter health checker responses

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
@@ -104,7 +104,8 @@ RUN sed -i /etc/httpd/conf.d/ssl.conf \
 RUN sed -i /etc/httpd/conf/httpd.conf \
     -e "s,Listen 80,Listen 8080," \
     -e "s,logs/error_log,/dev/stderr," \
-    -e "s,logs/access_log,/dev/stdout," \
+    -e "/<IfModule log_config_module>/a SetEnvIf User-Agent \"^kube-probe/\" dontlog" \
+    -e 's,CustomLog "logs/access_log" combined,CustomLog /dev/stdout combined env=!dontlog,' \
     -e "s,AllowOverride None,AllowOverride All," && \
     chmod a+rwX /etc/httpd/conf /run/httpd /etc/httpd/logs/
 STOPSIGNAL SIGWINCH

--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -102,7 +102,8 @@ RUN \
 RUN sed -i /etc/httpd/conf/httpd.conf \
     -e "s,Listen 80,Listen 8080," \
     -e "s,logs/error_log,/dev/stderr," \
-    -e "s,logs/access_log,/dev/stdout," \
+    -e "/<IfModule log_config_module>/a SetEnvIf User-Agent \"^kube-probe/\" dontlog" \
+    -e 's,CustomLog "logs/access_log" combined,CustomLog /dev/stdout combined env=!dontlog,' \
     -e "s,AllowOverride None,AllowOverride All," && \
     chmod a+rwX /etc/httpd/conf /etc/httpd/conf.d /run/httpd /etc/httpd/logs/
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Backporting chnages from https://github.com/redhat-developer/devspaces/pull/991 into devspaces-3.8-rhel-8. For more details check https://github.com/redhat-developer/devspaces/pull/991

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4610


#### How to test?
- Deploy DS
- Update devspaces CR to use custom images for devfile and plugin registries:
```
    devfileRegistry:
      deployment:
        containers:
          - image: quay.io/vsvydenk/devfileregistry-rhel8:3.8
.....

    pluginRegistry:
      deployment:
        containers:
          - image: quay.io/vsvydenk/pluginregistry-rhel8:3.8
```
- Wait when plugin and devfile registries pods will be restarted
- Check logs of the plugin and devfile registries pods from the OS console
- From the logs you shouldn't see messages like
```
"GET /devfiles/ HTTP/1.1" 200 8444 "-" "kube-probe/1.25"

"GET /v3/plugins/ HTTP/1.1" 200 1231 "http://10.128.151.66:8080/plugins/" "kube-probe/1.26"
``` 
![screenshot-nimbusweb me-2023 07 27-13_58_43](https://github.com/redhat-developer/devspaces/assets/1271546/9736e399-10c8-4069-aed6-fbeb53c891cc)


![screenshot-nimbusweb me-2023 07 27-13_53_04](https://github.com/redhat-developer/devspaces/assets/1271546/12ee39ed-f367-4493-961c-784adad48dd4)
