### PR TITLE
feat: publish vscode extensions at build time

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -110,7 +110,7 @@ USER postgres
 ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    PGDATA=/var/lib/pgsql/13/data/database \
+    PGDATA=/var/lib/pgsql/15/data/database \
     PATH="/tmp/opt/ovsx/bin:$PATH" \
     # use a cached version of the license list and not go over the internet
     # it's needed for openvsx server when vsix is publishing on AirGap environment
@@ -123,7 +123,18 @@ RUN \
     echo "======================" \
     echo -n "ovsx:  "; /tmp/opt/ovsx/bin/ovsx --version && \
     echo "======================"
-RUN chmod 777 /var/run/postgresql
+
+RUN chmod 777 /var/run/postgresql && \
+    initdb && \
+    /usr/local/bin/import_vsix.sh && \
+    chmod -R 777 /tmp/file && \
+    rm /var/lib/pgsql/15/data/database/postmaster.pid && \
+    rm /var/run/postgresql/.s.PGSQL* && \
+    rm /tmp/.s.PGSQL* && \
+    rm /tmp/.lock && \
+    chmod -R g+rwx /var/lib/pgsql && \
+    chgrp -R 0 /var/lib/pgsql && \
+    mv /var/lib/pgsql/15/data/database /var/lib/pgsql/15/data/old
 
 ARG DS_BRANCH=devspaces-3-rhel-8
 ENV DS_BRANCH=${DS_BRANCH}

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -59,8 +59,12 @@ function run_main() {
     
     # start only if wanted
     if [ "${START_OPENVSX}" == "true" ]; then
-      initdb
-      /usr/local/bin/import_vsix.sh
+      # change permissions
+      cp -r /var/lib/pgsql/15/data/old /var/lib/pgsql/15/data/database
+      rm -rf /var/lib/pgsql/15/data/old
+
+      # start postgres and openvsx
+      /usr/local/bin/start_services.sh
     fi
 
     # start httpd

--- a/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
@@ -48,3 +48,6 @@ done;
 
 # disable the personal access token
 psql -c "UPDATE personal_access_token SET active = false;"
+
+rm -rf /tmp/extension_*.vsix
+rm -rf /tmp/vsix


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Instead of publishing VSCode extensions at plugin registry runtime, it publishes them at buildtime (during the image's build).

It improves the time of starting the plugin registry pod and the memory usage of the pod.

![screenshot-devspaces apps rosa cuk6f-g9oz2-i8h ex2r p3 openshiftapps com-2023 08 23-16_36_04](https://github.com/redhat-developer/devspaces/assets/1271546/f86bdf50-9344-4dae-9756-6e106343054f)
![screenshot-console-openshift-console apps rosa cuk6f-g9oz2-i8h ex2r p3 openshiftapps com-2023 08 23-16_26_20](https://github.com/redhat-developer/devspaces/assets/1271546/cb42001f-d995-4e11-91ea-90ce41a328c7)
![screenshot-console-openshift-console apps rosa cuk6f-g9oz2-i8h ex2r p3 openshiftapps com-2023 08 23-16_25_39](https://github.com/redhat-developer/devspaces/assets/1271546/92118199-e711-4dda-b3c5-0f2aefcbb5db)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4650

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
N/A