### PR TITLE
chore: remove built-in js-debug extension

### DIFF
--- a/dependencies/che-plugin-registry/openvsx-sync.json
+++ b/dependencies/che-plugin-registry/openvsx-sync.json
@@ -15,9 +15,6 @@
         "id": "github.vscode-pull-request-github"
     },
     {
-        "id": "ms-vscode.js-debug"
-    },
-    {
         "id": "vscode.typescript-language-features"
     },
     {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Removes built-in js-debug extension from the list of embedded extensions

![screenshot-eclipse-che apps rosa xw5kt-fmr6p-pn5 pddx p3 openshiftapps com-2023 08 30-11_58_50](https://github.com/redhat-developer/devspaces/assets/1271546/ef8a4683-2850-4f7a-9577-deeb325380bf)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4817

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
