### PR TITLE
chore:wrap DS version in quotes

### DIFF
--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -1,6 +1,6 @@
 {
   "Purpose": "To set configurations of jenkins jobs including upstream branches, dependencies and disabled status",
-  "Version": 3.10,
+  "Version": "3.10",
   "Jobs": {
     "code": {
       "3.8": {

--- a/product/updateVersionAndRegistryTags.sh
+++ b/product/updateVersionAndRegistryTags.sh
@@ -100,7 +100,7 @@ replaceField()
   updateVal="$3"
   # shellcheck disable=SC2016 disable=SC2002 disable=SC2086
   if [[ ${theFile} == *".json" ]]; then
-    changed=$(cat "${theFile}" | jq ${updateName}' |= '"$updateVal")
+    changed=$(jq --arg updateVal "$updateVal" '.Version = $updateVal' "$theFile")
     echo "${changed}" > "${theFile}"
   elif [[ ${theFile} == *".yml" ]] || [[ ${theFile} == *".yaml" ]]; then
     changed=$(cat "${theFile}" | yq -Y --arg updateName "${updateName}" --arg updateVal "${updateVal}" ${updateName}' = $updateVal')

--- a/product/updateVersionAndRegistryTags.sh
+++ b/product/updateVersionAndRegistryTags.sh
@@ -100,7 +100,7 @@ replaceField()
   updateVal="$3"
   # shellcheck disable=SC2016 disable=SC2002 disable=SC2086
   if [[ ${theFile} == *".json" ]]; then
-    changed=$(jq --arg updateVal "$updateVal" '.Version = $updateVal' "$theFile")
+    changed=$(cat "${theFile}" | jq ${updateName}' |= '"$updateVal")
     echo "${changed}" > "${theFile}"
   elif [[ ${theFile} == *".yml" ]] || [[ ${theFile} == *".yaml" ]]; then
     changed=$(cat "${theFile}" | yq -Y --arg updateName "${updateName}" --arg updateVal "${updateVal}" ${updateName}' = $updateVal')
@@ -200,7 +200,11 @@ updateVersion() {
     # deprecated, @since 2.11
     echo "${DEVSPACES_VERSION}" > "${WORKDIR}/dependencies/VERSION"
     # @since 2.11
-    replaceField "${WORKDIR}/dependencies/job-config.json" '.Version' "${DEVSPACES_VERSION}"
+    
+    # replace value of .Version in job-config.json, we need arg to save quotes
+    changed=$(jq --arg version "$DEVSPACES_VERSION" ".Version = \$version" "${WORKDIR}/dependencies/job-config.json")
+    echo "${changed}" > "${WORKDIR}/dependencies/job-config.json"
+    
     replaceField "${WORKDIR}/dependencies/job-config.json" '.Copyright' "[\"${COPYRIGHT}\"]"
 
     DEVSPACES_Y_VALUE="${DEVSPACES_VERSION#*.}"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
The value of DS version should be wrapped in quotes to parse it correct by jq.

Some scripts use `jq -r '.Version' "${jobconfigjson}"` to get version of DS, without quotes we get 3.1 instead of 3.10.

### What issues does this PR fix or reference?
Fixes the plugin registry build

