### PR TITLE
chore: add vscode-dotnet-runtime extension

### DIFF
--- a/dependencies/che-plugin-registry/openvsx-sync.json
+++ b/dependencies/che-plugin-registry/openvsx-sync.json
@@ -87,6 +87,9 @@
         "id": "xdebug.php-debug"
     },
     {
+        "id": "ms-dotnettools.vscode-dotnet-runtime"
+    },
+    {
         "id": "muhammad-sammy.csharp"
     },
     {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds ms-dotnettools.vscode-dotnet-runtime extension into the list of embedded extensions as it is required by the latest version of muhammad-sammy.csharp

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4835

