### PR TITLE
chore: devfile registry should return index file by /index path

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
@@ -71,7 +71,7 @@ RUN ./check_referenced_images.sh devfiles --registries "${ALLOWED_REGISTRIES}" -
 RUN ./check_mandatory_fields.sh devfiles
 
 # Cache projects in DS 
-RUN ./index.sh > /build/devfiles/index.json && \
+RUN ./index.sh > /build/devfiles/index.json && cp /build/devfiles/index.json /build/index && \
     ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt && \
     ./list_referenced_images_by_file.sh devfiles > /build/devfiles/external_images_by_devfile.txt && \
     chmod -R g+rwX /build/devfiles /build/resources
@@ -119,6 +119,7 @@ RUN mkdir -m 777 /var/www/html/devfiles
 COPY README.md .htaccess /var/www/html/
 COPY --from=builder /build/devfiles /var/www/html/devfiles
 COPY --from=builder /build/resources /var/www/html/resources
+COPY --from=builder /build/devfiles/index.json /var/www/html/index
 COPY ./images /var/www/html/images
 COPY ./build/dockerfiles/rhel.entrypoint.sh ./build/dockerfiles/entrypoint.sh /usr/local/bin/
 RUN chmod g+rwX /usr/local/bin/entrypoint.sh /usr/local/bin/rhel.entrypoint.sh && \
@@ -134,6 +135,7 @@ RUN ./cache_projects.sh devfiles resources && \
 
 FROM registry AS offline-registry
 COPY --from=offline-builder /build/devfiles /var/www/html/devfiles
+COPY --from=offline-builder /build/devfiles/index.json /var/www/html/index
 COPY --from=offline-builder /build/resources /var/www/html/resources
 
 # append Brew metadata here


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
chore: devfile registry should return index file by /index path

Backport changes from https://github.com/eclipse-che/che-devfile-registry/pull/772

![screenshot-console-openshift-console apps ci-ln-x2zhsct-76ef8 origin-ci-int-aws dev rhcloud com-2023 09 15-13_08_49](https://github.com/redhat-developer/devspaces/assets/1271546/b978b303-bba4-4b55-b26c-48c41e599a0e)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22454

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
