### PR TITLE
chore: add devfile reg url to generated devworkspaces

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
@@ -61,6 +61,9 @@ function run_main() {
     # Add PUBLIC_URL at the begining of 'icon' and 'self' fields
     sed -i "s|\"icon\": \"/images/|\"icon\": \"${PUBLIC_URL}/images/|" "$INDEX_JSON"
     sed -i "s|\"self\": \"/devfiles/|\"self\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
+    sed -i "s|\"che-incubator/che-code/insiders\": \"/devfiles/|\"che-incubator/che-code/insiders\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
+    sed -i "s|\"che-incubator/che-code/latest\": \"/devfiles/|\"che-incubator/che-code/latest\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
+    sed -i "s|\"che-incubator/che-idea/latest\": \"/devfiles/|\"che-incubator/che-idea/latest\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
   else
     if grep -q '{{ DEVFILE_REGISTRY_URL }}' "${templates[@]}"; then
       echo "WARNING: environment variable 'CHE_DEVFILE_REGISTRY_URL' not configured" \


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Add CHE-DEVFILE-REGISTRY-URL as a prefix of generated devworkspaces into index.json

![screenshot-devspaces apps ci-ln-znxrnvt-76ef8 origin-ci-int-aws dev rhcloud com-2023 09 15-16_24_06](https://github.com/redhat-developer/devspaces/assets/1271546/4873a8dc-72c1-4fad-a777-e73f403361f2)

![screenshot-console-openshift-console apps ci-ln-znxrnvt-76ef8 origin-ci-int-aws dev rhcloud com-2023 09 15-16_23_41](https://github.com/redhat-developer/devspaces/assets/1271546/a93ed135-03dd-45b4-812d-c13f61180898)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4853
