### PR TITLE
fix: Fix cvs version prev in job-config.json.

### DIFF
--- a/dependencies/che-plugin-registry/deploy/openshift/devspaces-plugin-registry.yaml
+++ b/dependencies/che-plugin-registry/deploy/openshift/devspaces-plugin-registry.yaml
@@ -8,16 +8,6 @@
 #
 #  Contributors:
 #    Red Hat, Inc. - initial API and implementation
-#
-# Copyright (c) 2018-2023 Red Hat, Inc.
-#    This program and the accompanying materials are made
-#    available under the terms of the Eclipse Public License 2.0
-#    which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-#  SPDX-License-Identifier: EPL-2.0
-#
-#  Contributors:
-#    Red Hat, Inc. - initial API and implementation
 apiVersion: v1
 kind: Template
 metadata:

--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -532,15 +532,15 @@
       },
       "3.9": {
         "CSV_VERSION": "3.9.0",
-        "CSV_VERSION_PREV": ""
+        "CSV_VERSION_PREV": "3.8.0"
       },
       "3.10": {
         "CSV_VERSION": "3.10.0",
-        "CSV_VERSION_PREV": ""
+        "CSV_VERSION_PREV": "3.8.0"
       },
       "3.x": {
         "CSV_VERSION": "3.10.0",
-        "CSV_VERSION_PREV": ""
+        "CSV_VERSION_PREV": "3.8.0"
       }
     }
   },
@@ -661,9 +661,6 @@
       "3.9": "1.22.19",
       "3.10": "1.22.19",
       "3.x": "1.22.19"
-    },
-    "slack_notification": {
-      "3.8": true
     }
   },
   "Copyright": [

--- a/product/updateVersionAndRegistryTags.sh
+++ b/product/updateVersionAndRegistryTags.sh
@@ -308,9 +308,6 @@ updateVersion() {
 
     replaceField "${WORKDIR}/dependencies/job-config.json" ".Other[\"FLOATING_QUAY_TAGS\"][\"${LATEST_VERSION}\"]" "\"latest\""
 
-    # set slack notifications to true for latest version
-    replaceField "${WORKDIR}/dependencies/job-config.json" ".Other[\"slack_notification\"][\"${LATEST_VERSION}\"]" "true"
-
     # search for latest released tag to use for stable builds
     computeLatestPackageVersion $LATEST_VERSION "@eclipse-che/plugin-registry-generator"
     # or use "latest" release with replaceField "${WORKDIR}/dependencies/job-config.json" ".Other[\"@eclipse-che/plugin-registry-generator\"][\"${LATEST_VERSION}\"]" "\"latest\""


### PR DESCRIPTION
Fix csv version prev in job-config.json. 
Fix extra comment in pluginregistry yaml (and made note to investigate why that happens). 
Take slack notification update out of update script since it is no longer relevant.
