### PR TITLE
Fix source url in the output of product/getCommitSHAForTag.sh

### DIFF
--- a/product/getCommitSHAForTag.sh
+++ b/product/getCommitSHAForTag.sh
@@ -20,7 +20,7 @@ fi
 
 usage () {
 	echo "
-Usage: for 1 or more contains in quay or Pulp, compute the NVR, Build URL, and Source commit for that build. eg.,
+Usage: for 1 or more containers in quay or Pulp, compute the NVR, Build URL, and Source commit for that build. eg.,
   $0  quay.io/devspaces/udi-rhel8:3.y-1 quay.io/devspaces/udi-rhel8:3.y-1 ...
   $0  registry-proxy.engineering.redhat.com/rh-osbs/devspaces-udi-rhel8 -j 3.y -n 2      | show last 2 tags
 "

--- a/product/getCommitSHAForTag.sh
+++ b/product/getCommitSHAForTag.sh
@@ -20,7 +20,7 @@ fi
 
 usage () {
 	echo "
-Usage: for 1 or more containes in quay or Pulp, compute the NVR, Build URL, and Source commit for that build. eg., 
+Usage: for 1 or more contains in quay or Pulp, compute the NVR, Build URL, and Source commit for that build. eg.,
   $0  quay.io/devspaces/udi-rhel8:3.y-1 quay.io/devspaces/udi-rhel8:3.y-1 ...
   $0  registry-proxy.engineering.redhat.com/rh-osbs/devspaces-udi-rhel8 -j 3.y -n 2      | show last 2 tags
 "
@@ -90,6 +90,6 @@ for d in $CONTAINERS; do
 		# get the BUILD URL
 		echo "   Build: "$(brew buildinfo $NVR | grep "BUILD" | sed -e "s#.\+\[\([0-9]\+\)\].*#https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=\1#")
 		# get the sources URL
-		echo -n "  "; brew buildinfo $NVR | grep Source | sed -e "s#/containers#/cgit/containers#" -e "s#git:#https:#" -e "s%#%/commit?id=%"
+		echo -n "  "; brew buildinfo $NVR | grep Source | sed -e "s#/git/containers#/cgit/containers#" -e "s#git:#https:#" -e "s%#%/commit?id=%"
 	done
 done


### PR DESCRIPTION
### What does this PR do?
It fixes source URL generated by getCommitSHAForTag.sh in https://github.com/redhat-developer/devspaces/blob/devspaces-3-rhel-8/dependencies/LATEST_IMAGES_COMMITS.

Source URL before: [https://pkgs.devel.redhat.com/**git/cgit**/containers/devspaces-operator/commit?id=13f18757a803a8144e5e4b2ddf2b6a71601af1d1](https://pkgs.devel.redhat.com/git/cgit/containers/devspaces-operator/commit?id=13f18757a803a8144e5e4b2ddf2b6a71601af1d1)

Expected source URL: [https://pkgs.devel.redhat.com/**cgit**/containers/devspaces-operator/commit?id=13f18757a803a8144e5e4b2ddf2b6a71601af1d1](https://pkgs.devel.redhat.com/cgit/containers/devspaces-operator/commit?id=13f18757a803a8144e5e4b2ddf2b6a71601af1d1)

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
