### PR TITLE
chore: install runc manually to update to go1.19.12

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
@@ -45,7 +45,7 @@ if [[ ! -L /usr/bin/python ]]; then
 fi
 
 ${DNF} -y install \
-    java-17-openjdk httpd coreutils-single glibc-minimal-langpack glibc-langpack-en langpacks-en glibc-locale-source nc \
+    java-17-openjdk httpd runc coreutils-single glibc-minimal-langpack glibc-langpack-en langpacks-en glibc-locale-source nc \
     net-tools procps vi curl wget tar gzip jq findutils bash git skopeo \
     --releasever 8 --nodocs
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Trying to fix 
CVE-2023-29404 
CVE-2023-24540
CVE-2023-24538
CVE-2023-29405
CVE-2023-29402

All of them are related to go binary that comes with `runc` tool.
After installing runc manually:
```bash
bash-4.4$ runc -v
runc version 1.1.4
spec: 1.0.2-dev
go: go1.19.12
libseccomp: 2.5.2
``` 
before

```bash
bash-4.4$ runc -v
runc version 1.1.4
spec: 1.0.2-dev
go: go1.19.4
libseccomp: 2.5.2
```
### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4585

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
