### PR TITLE
fix: use https endpoints for the che-code editors

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -163,25 +163,25 @@ editors:
               targetPort: 3100
               exposure: public
               secure: true
-              protocol: http
+              protocol: https
             - name: code-redirect-1
               targetPort: 13131
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-2
               targetPort: 13132
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-3
               targetPort: 13133
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
@@ -249,25 +249,25 @@ editors:
               targetPort: 3100
               exposure: public
               secure: true
-              protocol: http
+              protocol: https
             - name: code-redirect-1
               targetPort: 13131
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-2
               targetPort: 13132
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-3
               targetPort: 13133
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false


### PR DESCRIPTION
### What does this PR do?

fix: use https endpoints for the che-code editors


### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-4869

upstream PR - https://github.com/eclipse-che/che-plugin-registry/pull/1810


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
