### PR TITLE
fix: use https endpoints for the che-code editors (#1022)

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -163,25 +163,25 @@ editors:
               targetPort: 3100
               exposure: public
               secure: true
-              protocol: http
+              protocol: https
             - name: code-redirect-1
               targetPort: 13131
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-2
               targetPort: 13132
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-3
               targetPort: 13133
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
@@ -249,25 +249,25 @@ editors:
               targetPort: 3100
               exposure: public
               secure: true
-              protocol: http
+              protocol: https
             - name: code-redirect-1
               targetPort: 13131
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-2
               targetPort: 13132
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false
             - name: code-redirect-3
               targetPort: 13133
               exposure: public
-              protocol: http
+              protocol: https
               attributes:
                 discoverable: false
                 urlRewriteSupported: false


### PR DESCRIPTION
Cherry-pick of the https://github.com/redhat-developer/devspaces/pull/1022

Related issue https://issues.redhat.com/browse/CRW-4869