### PR TITLE
chore: CRW-5536 bump to traefik...

### DIFF
--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -319,15 +319,15 @@
       },
       "3.11": {
         "upstream_branch": [
-          "v2.9.6",
-          "v2.9.6"
+          "v2.9.10",
+          "v2.9.10"
         ],
         "disabled": false
       },
       "3.x": {
         "upstream_branch": [
-          "v2.9.6",
-          "v2.9.6"
+          "v2.9.10",
+          "v2.9.10"
         ],
         "disabled": false
       }


### PR DESCRIPTION
### What does this PR do?

chore: CRW-5536 bump to traefik v2.9.10

Change-Id: I82db10ec0231d0d02e081cdc443f178450f88a1a
Signed-off-by: nickboldt <nickboldt@gmail.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.