### PR TITLE
fix: bump postgresql-15 base image for plugin reg

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@
 #
 
 # https://registry.access.redhat.com/rhel8/postgresql-15
-FROM registry.redhat.io/rhel8/postgresql-15:1-39
+FROM registry.redhat.io/rhel8/postgresql-15:1-50.1708914865
 USER 0
 WORKDIR /
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Bump registry.redhat.io/rhel8/postgresql-15 image to 1-50.1708914865

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5767
