### PR TITLE
Update getLatestImageTags.sh

### DIFF
--- a/product/getLatestImageTags.sh
+++ b/product/getLatestImageTags.sh
@@ -366,15 +366,15 @@ for URLfrag in $CONTAINERS; do
 	# shellcheck disable=SC2001
 	QUERY="$(echo "$URL" | sed -e "s#.\+\(registry.redhat.io\|registry.access.redhat.com\)/#skopeo inspect ${ARCH_OVERRIDE} docker://${REGISTRYPRE}#g")${searchTag}"
 	if [[ $VERBOSE -eq 1 ]]; then 
-		echo ""; echo -n "LATESTTAGs=\"\$($QUERY | jq -r .RepoTags[] | grep -E -v '${EXCLUDES}' | grep -E '${BASETAG}' | sort -V)\"; "
+		echo ""; echo -n "LATESTTAGs=\"\$($QUERY | jq -r .RepoTags[] | grep -E -v '${EXCLUDES}' | grep -E -w '${BASETAG}' | sort -V)\"; "
 	fi
-	LATESTTAGs="$(${QUERY} 2>/dev/null | jq -r .RepoTags[] | grep -E -v "${EXCLUDES}" | grep -E "${BASETAG}" | sort -V)"
+	LATESTTAGs="$(${QUERY} 2>/dev/null | jq -r .RepoTags[] | grep -E -v "${EXCLUDES}" | grep -E -w "${BASETAG}" | sort -V)"
 	if [[ ! ${LATESTTAGs} ]]; then # try again with -container suffix
 		QUERY="$(echo "${URL}-container" | sed -e "s#.\+\(registry.redhat.io\|registry.access.redhat.com\)/#skopeo inspect ${ARCH_OVERRIDE} docker://${REGISTRYPRE}#g")"
 		if [[ $VERBOSE -eq 1 ]]; then 
-		    echo ""; echo -n "LATESTTAGs=\"\$($QUERY | jq -r .RepoTags[] | grep -E -v '${EXCLUDES}' | grep -E '${BASETAG}' | sort -V)\"; " 
+		    echo ""; echo -n "LATESTTAGs=\"\$($QUERY | jq -r .RepoTags[] | grep -E -v '${EXCLUDES}' | grep -E -w '${BASETAG}' | sort -V)\"; " 
 		fi
-		LATESTTAGs="$(${QUERY} 2>/dev/null | jq -r .RepoTags[] | grep -E -v "${EXCLUDES}" | grep -E "${BASETAG}" | sort -V)"
+		LATESTTAGs="$(${QUERY} 2>/dev/null | jq -r .RepoTags[] | grep -E -v "${EXCLUDES}" | grep -E -w "${BASETAG}" | sort -V)"
 	fi
 
 	# exclude freshmaker containers and/or sort and grab only the last n tags


### PR DESCRIPTION
Add -w to grep for base tag so it doesn't pick up similar tags from other releases

i.e finding 3.13-12 instead of 3.12-166
https://issues.redhat.com/browse/CRW-5774