### PR TITLE
Updating calls to getLatestImageTags.sh

### DIFF
--- a/dependencies/LATEST_IMAGES.sh
+++ b/dependencies/LATEST_IMAGES.sh
@@ -56,7 +56,7 @@ if [[ $DWNSTM_BRANCH != "devspaces-3."*"-rhel-8" ]] && [[ $DWNSTM_BRANCH != "dev
 fi
 
 # STEP 1 :: regenerate image tag list in LATEST_IMAGES
-CMD="./product/getLatestImageTags.sh --quay -b ${DWNSTM_BRANCH} --tag ${VERSION}- --hide"
+CMD="./product/getLatestImageTags.sh --quay -b ${DWNSTM_BRANCH} --tag ${VERSION} --hide"
 # shellcheck disable=SC2086
 echo $CMD
 $CMD | tee dependencies/LATEST_IMAGES

--- a/product/copyDWOToQuay.sh
+++ b/product/copyDWOToQuay.sh
@@ -60,7 +60,7 @@ if [[ ! $PROD_VER ]]; then usage; exit 1; fi
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 
 # 1. use getLatestImageTags.sh to get latest bundle in an IIB - return: operator-bundle:0.16-5 
-bundle=$(${SCRIPT_DIR}/getLatestImageTags.sh --osbs -c devworkspace-operator-bundle --tag "${PROD_VER}-")
+bundle=$(${SCRIPT_DIR}/getLatestImageTags.sh --osbs -c devworkspace-operator-bundle --tag "${PROD_VER}")
 if [[ ! $bundle ]]; then
     errorf "Could not compute latest bundle! "
     exit 2

--- a/product/copyIIBsToQuay.sh
+++ b/product/copyIIBsToQuay.sh
@@ -190,8 +190,8 @@ for OCP_VER in ${OCP_VERSIONS}; do
     fi 
 
     if [[ $VERBOSEFLAG == "-v" ]]; then
-        echo "[DEBUG] LATEST DS  OPERATOR BUNDLE = $(${getLatestImageTags} --osbs -c devspaces-operator-bundle --tag "${DS_VERSION}-")"
-        echo "[DEBUG] LATEST DWO OPERATOR BUNDLE = $(${getLatestImageTags} --osbs -c devworkspace-operator-bundle --tag "${DWO_VERSION}-")"
+        echo "[DEBUG] LATEST DS  OPERATOR BUNDLE = $(${getLatestImageTags} --osbs -c devspaces-operator-bundle --tag "${DS_VERSION}")"
+        echo "[DEBUG] LATEST DWO OPERATOR BUNDLE = $(${getLatestImageTags} --osbs -c devworkspace-operator-bundle --tag "${DWO_VERSION}")"
         echo "[DEBUG] Note that the above bundles might not yet exist for the latest IIB, if still being published."
         echo ""
         echo "[DEBUG] DS     INDEX BUNDLE = ${LATEST_IIB}"

--- a/product/util2.groovy
+++ b/product/util2.groovy
@@ -436,7 +436,7 @@ fi
   return sh(
     returnStdout: true, 
     // -b devspaces-3.0-rhel-8 -c devspaces/server-rhel8 --tag "3.0-" --quay
-    script: './getLatestImageTags.sh -b ' + MIDSTM_BRANCH + ' -c "' + orgAndImage + '" --tag "' + tag + '-" --' + repo
+    script: './getLatestImageTags.sh -b ' + MIDSTM_BRANCH + ' -c "' + orgAndImage + '" --tag "' + tag + '" --' + repo
   ).trim()
 }
 


### PR DESCRIPTION
Removing the dash from after the tag in calls to getLatestImageTags.sh because it didn't save us from 3.13-12 and is now breaking things.



### What does this PR do?


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5774