### PR TITLE
Set traefik to v2.10.0

### DIFF
--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -319,15 +319,15 @@
       },
       "3.13": {
         "upstream_branch": [
-          "v2.11.0",
-          "v2.11.0"
+          "v2.10.0",
+          "v2.10.0"
         ],
         "disabled": false
       },
       "3.x": {
         "upstream_branch": [
-          "v2.11.0",
-          "v2.11.0"
+          "v2.10.0",
+          "v2.10.0"
         ],
         "disabled": false
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-5765
We can't update to 2.11.0 because Cachito is currently incapable of vendoring go 1.22 builds.