### PR TITLE
chore: upgrade local plugin registry to use openvsx-server 0.14.5

### DIFF
--- a/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/import_vsix.sh
@@ -41,6 +41,7 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
 
     # publish the file
     ovsx publish "${vsixFilename}"
+    sleep 5
 
     # remove the downloaded file
     rm "${vsixFilename}"

--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -607,8 +607,8 @@
     "CHE_OPENVSX_TAG": {
       "3.11": "che-openvsx-v0.14.2",
       "3.12": "che-openvsx-v0.14.2",
-      "3.13": "che-openvsx-v0.14.2",
-      "3.x": "che-openvsx-v0.14.2"
+      "3.13": "che-openvsx-v0.14.5",
+      "3.x": "che-openvsx-v0.14.5"
     },
     "@eclipse-che/plugin-registry-generator": {
       "3.11": "7.80.0",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

- Upgrade openvsx-server base image to 0.14.5
- Set timeout after publishing each extension to be initialized properly

![screenshot-devspaces apps rosa azccv-63faw-u8v om9c p3 openshiftapps com-2024 03 21-15_59_52](https://github.com/redhat-developer/devspaces/assets/1271546/f7da3dbc-12d3-4557-93ac-dafb36719639)


![screenshot-console-openshift-console apps rosa azccv-63faw-u8v om9c p3 openshiftapps com-2024 03 21-16_01_11](https://github.com/redhat-developer/devspaces/assets/1271546/f474ee3e-abc0-4981-af91-928716262532)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5751

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
