### PR TITLE
make it possible to use rhel9-2-els image in Brew build

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -13,6 +13,8 @@
 
 # https://registry.access.redhat.com/rhel8/postgresql-15
 FROM registry.redhat.io/rhel8/postgresql-15:1-50.1708914865
+# rhel9-2-els is used for the build in Brew
+# FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 USER 0
 WORKDIR /
 
@@ -41,6 +43,9 @@ ENV BOOTSTRAP=${BOOTSTRAP}
 COPY ./build/dockerfiles/content_set*.repo /etc/yum.repos.d/
 COPY ./build/dockerfiles/rhel.install.sh /tmp
 RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
+
+# Install postgresql and nodejs into rhel9-2-els
+# RUN dnf module install postgresql:15/server nodejs:18/development -y
 
 # Copy OpenVSX server files
 COPY --chown=0:0 /openvsx-server.tar.gz .
@@ -135,8 +140,8 @@ RUN chmod 777 /var/run/postgresql && \
 
 RUN \
     echo "Change permissions for postgres user" && \
-    chmod -R g+rwx /var/lib/pgsql/15 /var/lib/pgsql/data /var/lib/pgsql/backups && \
-    chgrp -R 0 /var/lib/pgsql/15 /var/lib/pgsql/data /var/lib/pgsql/backups && \
+    chmod -R g+rwx /var/lib/pgsql/15 /var/lib/pgsql/15 /var/lib/pgsql/data /var/lib/pgsql/backups && \
+    chgrp -R 0 /var/lib/pgsql/15 /var/lib/pgsql/15 /var/lib/pgsql/data /var/lib/pgsql/backups && \
     mv /var/lib/pgsql/15/data/database /var/lib/pgsql/15/data/old
 
 ARG DS_BRANCH=devspaces-3-rhel-8

--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -11,6 +11,7 @@
 #   IBM Corporation - implementation
 #
 
+# https://registry.access.redhat.com/rhel8/postgresql-15
 FROM registry.redhat.io/rhel8/postgresql-15:1-50.1708914865
 USER 0
 WORKDIR /

--- a/dependencies/che-plugin-registry/build/dockerfiles/content_sets_rhel9.repo
+++ b/dependencies/che-plugin-registry/build/dockerfiles/content_sets_rhel9.repo
@@ -1,0 +1,13 @@
+[rhel-9-for-appstream-rpms-pulp]
+name=rhel-9-for-appstream-rpms-pulp
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/$basearch/appstream/os
+enabled=0
+gpgcheck=0
+skip_if_unavailable=True
+ 
+[rhel-9-for-baseos-rpms-pulp]
+name=rhel-9-for-baseos-rpms-pulp
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/$basearch/baseos/os
+enabled=0
+gpgcheck=0
+skip_if_unavailable=True

--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
@@ -11,6 +11,7 @@
 #   IBM Corporation - implementation
 #
 
+# https://registry.access.redhat.com/rhel9-2-els/rhel
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 USER 0
 WORKDIR /

--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
@@ -37,7 +37,7 @@ ENV BOOTSTRAP=${BOOTSTRAP}
 # built in Brew, use tarball in lookaside cache; built locally with BOOTSTRAP = true, comment this out to create the tarball
 # COPY root-local.tgz /tmp/root-local.tgz
 
-COPY ./build/dockerfiles/content_set*.repo /etc/yum.repos.d/
+COPY ./build/dockerfiles/content_sets_rhel9.repo /etc/yum.repos.d/
 COPY ./build/dockerfiles/rhel.install.sh /tmp
 RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
 

--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
@@ -11,7 +11,7 @@
 #   IBM Corporation - implementation
 #
 
-FROM registry.redhat.io/rhel8/postgresql-15:1-50.1708914865
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 USER 0
 WORKDIR /
 
@@ -40,6 +40,9 @@ ENV BOOTSTRAP=${BOOTSTRAP}
 COPY ./build/dockerfiles/content_set*.repo /etc/yum.repos.d/
 COPY ./build/dockerfiles/rhel.install.sh /tmp
 RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
+
+# Install postgresql and nodejs
+RUN dnf module install postgresql:15/server nodejs:18/development -y
 
 # Copy OpenVSX server files
 COPY --chown=0:0 /openvsx-server.tar.gz .

--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.install.sh
@@ -46,7 +46,7 @@ fi
 
 ${DNF} -y install \
     java-17-openjdk httpd runc coreutils-single glibc-minimal-langpack glibc-langpack-en langpacks-en glibc-locale-source nc \
-    net-tools procps vi curl wget tar gzip jq findutils bash git skopeo \
+    net-tools procps vi wget tar gzip jq findutils bash git skopeo \
     --releasever 8 --nodocs
 
 ${DNF} -y module reset nodejs && \


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use rhel9-2-els image for the build in Brew

We still have registry.redhat.io/rhel8/postgresql-15 image in the main Dockerfile for the custom plugin registry build

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6350
