### PR TITLE
chore: bump openvsx-server to v0.15.8

### DIFF
--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -607,8 +607,8 @@
     "CHE_OPENVSX_TAG": {
       "3.14": "che-openvsx-v0.14.5",
       "3.15": "che-openvsx-v0.14.5",
-      "3.16": "che-openvsx-v0.14.5",
-      "3.x": "che-openvsx-v0.14.5"
+      "3.16": "che-openvsx-v0.15.8",
+      "3.x": "che-openvsx-v0.15.8"
     },
     "@eclipse-che/plugin-registry-generator": {
       "3.14": "7.86.0",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Bump openvsx-server to v0.15.8 version, in this new version spring-security 6.1.9 is used 

![screenshot-nimbusweb me-2024 07 11-15_58_06](https://github.com/redhat-developer/devspaces/assets/1271546/33d9ae34-1ada-4050-9e9d-800ec0615a62)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6010

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
