### PR TITLE
extension's vscode engine version * should be compatible with all VS Code editors

### DIFF
--- a/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
+++ b/dependencies/che-plugin-registry/build/scripts/download_vsix.sh
@@ -148,7 +148,7 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
         vscodeEngineVersion="${vscodeEngineVersion//x/0}"
         # check if the extension's engine version is compatible with the code version
         # if the extension's engine version is ahead of the code version, print an error
-        if [[ "$vscodeEngineVersion" != "$(echo -e "$vscodeEngineVersion\n$codeVersion" | sort -V | head -n1)" ]]; then
+        if [[ "$vscodeEngineVersion" != "*" && "$vscodeEngineVersion" != "$(echo -e "$vscodeEngineVersion\n$codeVersion" | sort -V | head -n1)" ]]; then
             echo "Version ${vsixVersion} of ${vsixName} is not compatible with VS Code editor $codeVersion"
             exit 1
         fi
@@ -185,8 +185,11 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
     # replace x by 0 in the engine version
     vscodeEngineVersion="${vscodeEngineVersion//x/0}"
     # check if the extension's engine version is compatible with the code version
+    # if the extension's engine version is '*', it means the extension is compatible with any VS Code version
+    if [[ "$vscodeEngineVersion" == "*" ]]; then
+        echo -e "${GREEN}${EMOJI_PASS}${RESETSTYLE} compatible."
     # if the extension's engine version is ahead of the code version, check a next version of the extension
-    if [[ "$vscodeEngineVersion" = "$(echo -e "$vscodeEngineVersion\n$codeVersion" | sort -V | head -n1)" ]]; then
+    elif [[ "$vscodeEngineVersion" = "$(echo -e "$vscodeEngineVersion\n$codeVersion" | sort -V | head -n1)" ]]; then
         #VS Code version >= Engine version, can proceed."
         echo -e "${GREEN}${EMOJI_PASS}${RESETSTYLE} compatible."
     else


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
If vsix extension's vscode engine version is `*`, it should be compatible with all VS Code editor versions

### How to test? 
1/ Update openvsx-sync.json file by replacing the content with:
```
[
  {
    "id": "magicstack.MagicPython",
    "version": "1.1.1"
  }
]
```
It contains magicstack.MagicPython extension which has [vscode engine version *](https://github.com/MagicStack/MagicPython/blob/master/package.json#L7)
2/ Try to build plugin registry by executing ./build.sh script
3/ Extension should be downloaded and published to the plugin registry

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6803
