### PR TITLE
chore: add open-collaboration-tools extension into the embedded plugin reg

### DIFF
--- a/dependencies/che-plugin-registry/openvsx-sync.json
+++ b/dependencies/che-plugin-registry/openvsx-sync.json
@@ -210,5 +210,9 @@
   {
     "id": "Continue.continue",
     "version": "0.8.44"
+  },
+  {
+    "id": "typefox.open-collaboration-tools",
+    "version": "0.1.1"
   }
 ]


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds [Open Collaboration Tools extension](https://open-vsx.org/extension/typefox/open-collaboration-tools) into the embedded plugin registry

![screenshot-devspaces apps rosa tjnhf-qocfq-yg3 nnbd p3 openshiftapps com-2024 08 13-11_01_45](https://github.com/user-attachments/assets/b0f277db-a7aa-45ad-966f-fc1ee7e72227)

**It could be tested with quay.io/vsvydenk/pluginregistry-rhel8:next image**

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6874

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add [Open Collaboration Tools extension](https://open-vsx.org/extension/typefox/open-collaboration-tools) into the Embedded plugin registry

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
