### PR TITLE
Update openvsx config; remove /v3/plugins from the container

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -54,8 +54,6 @@ RUN mkdir -p /tmp/opt
 COPY --chown=0:0 /ovsx.tar.gz .
 RUN tar -xf ovsx.tar.gz -C / && rm ovsx.tar.gz && ls -la /tmp/opt/ovsx/bin/
 
-RUN mkdir -p /var/www/html/v3/plugins/
-
 RUN \
     # Apply permissions to later change these files on httpd
     chmod g+rwx /var/log/httpd && chmod g+rw /run/httpd && \
@@ -92,8 +90,6 @@ RUN \
 RUN sed -i /etc/httpd/conf/httpd.conf \
     -e "s,Listen 80,Listen 8080," \
     -e "s,logs/error_log,/dev/stderr," \
-    -e "/<IfModule log_config_module>/a SetEnvIf User-Agent \"^kube-probe/\" dontlog" \
-    -e 's,CustomLog "logs/access_log" combined,CustomLog /dev/stdout combined env=!dontlog,' \
     -e "s,AllowOverride None,AllowOverride All," && \
     chmod a+rwX /etc/httpd/conf /etc/httpd/conf.d /run/httpd /etc/httpd/logs/
 

--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -90,6 +90,8 @@ RUN \
 RUN sed -i /etc/httpd/conf/httpd.conf \
     -e "s,Listen 80,Listen 8080," \
     -e "s,logs/error_log,/dev/stderr," \
+    -e "/<IfModule log_config_module>/a SetEnvIf User-Agent \"^kube-probe/\" dontlog" \
+    -e 's,CustomLog "logs/access_log" combined,CustomLog /dev/stdout combined env=!dontlog,' \
     -e "s,AllowOverride None,AllowOverride All," && \
     chmod a+rwX /etc/httpd/conf /etc/httpd/conf.d /run/httpd /etc/httpd/logs/
 

--- a/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
+++ b/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
@@ -49,3 +49,5 @@ ovsx:
     clear-on-start: true
   databasesearch:
     enabled: true
+  registry:
+    version: 'v0.15.8'


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
- We don't need /v3/plugins/ folder anymore
- Add version of openvsx registry into server config

Dependent PR: https://github.com/eclipse-che/che-operator/pull/1894 

### What issues does this PR fix or reference?
Related to https://github.com/eclipse-che/che/issues/23074
