### PR TITLE
chore: add vscode-task-manager and vscode-sshfs extensions

### DIFF
--- a/dependencies/che-plugin-registry/openvsx-sync.json
+++ b/dependencies/che-plugin-registry/openvsx-sync.json
@@ -214,5 +214,13 @@
   {
     "id": "typefox.open-collaboration-tools",
     "version": "0.2.4"
+  },
+  {
+    "id": "cnshenj.vscode-task-manager",
+    "version": "1.0.0"
+  },
+  {
+    "id": "Kelvin.vscode-sshfs",
+    "version": "1.26.1"
   }
 ]


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds `cnshenj.vscode-task-manager` and `Kelvin.vscode-sshfs` into the embedded plugin registry

![screenshot-devspaces_apps_rosa_nowi9-r8p69-p5j_y4d6_p3_openshiftapps_com-2024_10_08-10_58_48](https://github.com/user-attachments/assets/46fc9363-377a-44b4-a648-750ae4491b8f)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-7481
https://issues.redhat.com/browse/CRW-7482

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add [cnshenj.vscode-task-manager](https://open-vsx.org/extension/cnshenj/vscode-task-manager) and [Kelvin.vscode-sshfs](https://open-vsx.org/extension/Kelvin/vscode-sshfs) extensions into the embedded plugin registry

