### PR TITLE
chore: Skip Zipkin traces for plugin registry

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
+++ b/dependencies/che-plugin-registry/build/dockerfiles/application.yaml
@@ -8,6 +8,7 @@ spring:
   autoconfigure:
     exclude: 
       - org.jobrunr.spring.autoconfigure.storage.JobRunrElasticSearchStorageAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration
   cache:
     jcache:
       config: classpath:ehcache.xml


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Don't send traces to Zipkin when extensions are installing. The logs in the plugin registry pod are now clearer and more readable:

![screenshot-github_com-2024_10_10-16_08_44](https://github.com/user-attachments/assets/c848e532-d57b-43c7-82cd-adb1847c4617)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-7257

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
