### PR TITLE
fix: skip update of image refs for dotnet-web-simple sample

### DIFF
--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -172,7 +172,13 @@ pushBranchAndOrTagGH () {
 
 		# for the devspaces sample repos, update devfiles to point to the correct tag/branch
 		if [[ "$isSample" == "sample" ]]; then
-			updateSampleDevfileReferences
+			# exclude samples with images that use community images e.g. dotnet-web-simple
+			if [[ "$d" == "dotnet-web-simple" ]]; then
+				echo "[DEBUG] Skipping update of image references in devfile for sample: $d"
+			else
+				echo "[DEBUG] Updating image references in devfile for sample: $d"
+				updateSampleDevfileReferences
+			fi
 		fi
 
 		git pull origin "${TARGET_BRANCH}" || true


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Running tagRelease.sh has caused one devfile sample to have corrupted digest.
The script that processed that digest  will now exclude this sample, because it doesn't need it (it uses a community image with pinned digest, that shouldn't be changed

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-9199

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
